### PR TITLE
0.8.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeshIntegrals"
 uuid = "dadec2fd-bbe0-4da4-9dbe-476c782c8e47"
 authors = ["Mike Ingold <mike.ingold@gmail.com>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
@@ -24,4 +24,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["DynamicQuantities", "Meshes", "Test", "QuadGK", "Unitful"]
+test = ["DynamicQuantities", "Meshes", "Test", "Unitful"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeshIntegrals"
 uuid = "dadec2fd-bbe0-4da4-9dbe-476c782c8e47"
 authors = ["Mike Ingold <mike.ingold@gmail.com>"]
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Methods are tested to ensure compatibility with
 | Symbol | Meaning |
 |--------|---------|
 | :white_check_mark: | Implemented, passes tests |
+| :green_circle: | Implemented (implicit conversion), passes tests |
 | :yellow_square: | Implemented, untested |
 | :x: | Not yet implemented |
 
@@ -29,6 +30,7 @@ Methods are tested to ensure compatibility with
 | `Meshes.BezierCurve` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Box{2,T}` | :x: | :x: |
 | `Meshes.Circle` | :white_check_mark: | :white_check_mark: |
+| `Meshes.Disk` | :yellow_square: | :yellow_square: |
 | `Meshes.Ngon` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Point...` | :x: | :x: |
 | `Meshes.Ring` | :white_check_mark: | :white_check_mark: |
@@ -41,7 +43,8 @@ Methods are tested to ensure compatibility with
 | `Meshes.Ball` | :x: | :x: | :x: |
 | `Meshes.Box{2,T}` | :white_check_mark: | :white_check_mark: | :x: |
 | `Meshes.Box{>2,T}` | :x: | :x: | :x: |
-| `Meshes.Circle` | :x: | :x: | :x: |
+| `Meshes.Circle` | :yellow_square: | :yellow_square: | :x: |
+| `Meshes.Disk` | :yellow_square: | :yellow_square: | :x: |
 | `Meshes.Sphere` | :x: | :x: | :x: |
 | `Meshes.Ngon` | :x: | :x: | :x: |
 | `Meshes.Triangle` | :white_check_mark: | :white_check_mark: | :x: |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Methods are tested to ensure compatibility with
 | `Meshes.BezierCurve` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Box{2,T}` | :x: | :x: |
 | `Meshes.Circle` | :white_check_mark: | :white_check_mark: |
-| `Meshes.Disk` | :yellow_square: | :yellow_square: |
+| `Meshes.Disk` | :green_circle: | :green_circle: |
 | `Meshes.Ngon` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Point...` | :x: | :x: |
 | `Meshes.Ring` | :white_check_mark: | :white_check_mark: |
@@ -43,8 +43,8 @@ Methods are tested to ensure compatibility with
 | `Meshes.Ball` | :x: | :x: | :x: |
 | `Meshes.Box{2,T}` | :white_check_mark: | :white_check_mark: | :x: |
 | `Meshes.Box{>2,T}` | :x: | :x: | :x: |
-| `Meshes.Circle` | :yellow_square: | :yellow_square: | :x: |
-| `Meshes.Disk` | :yellow_square: | :yellow_square: | :x: |
+| `Meshes.Circle` | :green_circle: | :green_circle: | :x: |
+| `Meshes.Disk` | :white_check_mark: | :white_check_mark: | :x: |
 | `Meshes.Sphere` | :x: | :x: | :x: |
 | `Meshes.Ngon` | :x: | :x: | :x: |
 | `Meshes.Triangle` | :white_check_mark: | :white_check_mark: | :x: |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Methods are tested to ensure compatibility with
 |----------|----------------|---------------|
 | `Meshes.BezierCurve` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Box{2,T}` | :x: | :x: |
-| `Meshes.Circle` | :x: | :x: |
+| `Meshes.Circle` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Ngon` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Point...` | :x: | :x: |
 | `Meshes.Ring` | :white_check_mark: | :white_check_mark: |
@@ -39,11 +39,12 @@ Methods are tested to ensure compatibility with
 | Geometry | Gauss-Legendre | Gauss-Kronrod | H-Adaptive Cubature |
 |----------|----------------|---------------|-------------------|
 | `Meshes.Ball` | :x: | :x: | :x: |
-| `Meshes.Box{Dim,T}` | :x: | :x: | :x: |
+| `Meshes.Box{2,T}` | :white_check_mark: | :white_check_mark: | :x: |
+| `Meshes.Box{>2,T}` | :x: | :x: | :x: |
 | `Meshes.Circle` | :x: | :x: | :x: |
 | `Meshes.Sphere` | :x: | :x: | :x: |
 | `Meshes.Ngon` | :x: | :x: | :x: |
-| `Meshes.Triangle` | :yellow_square: | :yellow_square: | :x: |
+| `Meshes.Triangle` | :white_check_mark: | :white_check_mark: | :x: |
 
 ### Volume Integrals
 | Geometry | Gauss-Legendre | H-Adaptive Cubature |

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -179,8 +179,8 @@ function surfaceintegral(
     g(((wi,wj), (xρ,xϕ))) = wi * wj * s(xρ) * f(point(xρ,xϕ))
 
     # Calculate 2D Gauss-Legendre integral of f over parametric coordinates [-1,1]²
-    # Apply a linear domain-correction factor [-1,1]² ↦ area(disk)
-    return 0.25 * area(disk) .* sum(g, zip(wws,xxs))
+    # Apply curvilinear domain-correction factor [-1,1]² ↦ area(disk)
+    return 0.5 * area(disk) .* sum(g, zip(wws,xxs))
 end
 
 function surfaceintegral(

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -107,7 +107,7 @@ end
 
 function surfaceintegral(
     f,
-    rect::Meshes.Box{2,T},
+    box::Meshes.Box{2,T},
     settings::GaussLegendre
 ) where {T}
     # Validate the provided integrand function
@@ -121,14 +121,14 @@ function surfaceintegral(
     # Domain transformation: u,v [-1,1] ↦ s,t [0,1]
     s(u) = 0.5u + 0.5
     t(v) = 0.5v + 0.5
-    point(xi,xj) = rect(s(xi), t(xj))
+    point(xi,xj) = box(s(xi), t(xj))
 
     # Calculate weight-node product
     g(((wi,wj), (xi,xj))) = wi * wj * f(point(xi,xj))
 
     # Calculate 2D Gauss-Legendre integral of f over parametric coordinates [-1,1]^2
-    # Apply a linear domain-correction factor [-1,1]^2 ↦ area(rect)
-    return 0.25 * area(rect) .* sum(g, zip(wws,xxs))
+    # Apply a linear domain-correction factor [-1,1]^2 ↦ area(box)
+    return 0.25 * area(box) .* sum(g, zip(wws,xxs))
 end
 
 function surfaceintegral(
@@ -144,7 +144,7 @@ function surfaceintegral(
     outerintegral = QuadGK.quadgk(innerintegral, 0, 1; settings.kwargs...)[1]
 
     # Apply a linear domain-correction factor 1 ↦ area(box)
-    return area(rect) .* outerintegral
+    return area(box) .* outerintegral
 end
 
 """

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -106,6 +106,16 @@ end
 ################################################################################
 
 function surfaceintegral(
+    f::F,
+    circle::Meshes.Circle,
+    settings::I
+) where {F<:Function, I<:IntegrationAlgorithm}
+    # Circle is parametrically 1-dimensional
+    # Convert to a Disk, integrate that
+    return surfaceintegral(f, Disk(circle.plane, circle.radius), settings)
+end
+
+function surfaceintegral(
     f,
     box::Meshes.Box{2,T},
     settings::GaussLegendre

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -176,7 +176,7 @@ function surfaceintegral(
     point(xi,xj) = disk(s(xi), t(xj))
 
     # Calculate weight-node product with curvilinear correction
-    g(((wi,wj), (xρ,xϕ))) = wi * wj * xρ * f(point(xρ,xϕ))
+    g(((wi,wj), (xρ,xϕ))) = wi * wj * s(xρ) * f(point(xρ,xϕ))
 
     # Calculate 2D Gauss-Legendre integral of f over parametric coordinates [-1,1]²
     # Apply a linear domain-correction factor [-1,1]² ↦ area(disk)
@@ -196,7 +196,7 @@ function surfaceintegral(
     outerintegral = QuadGK.quadgk(innerintegral, 0, 1; settings.kwargs...)[1]
 
     # Apply a linear domain-correction factor π ↦ area(disk)
-    return (area(disk) / π) .* outerintegral
+    return 2π .* outerintegral
 end
 
 """

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -109,9 +109,9 @@ function surfaceintegral(
     f,
     rect::Meshes.Box{2,T},
     settings::GaussLegendre
-) where {Dim, T}
+) where {T}
     # Validate the provided integrand function
-    _validate_integrand(f,Dim,T)
+    _validate_integrand(f,2,T)
 
     # Get Gauss-Legendre nodes and weights for a 2D region [-1,1]^2
     xs, ws = gausslegendre(settings.n)
@@ -135,9 +135,9 @@ function surfaceintegral(
     f,
     box::Meshes.Box{2,T},
     settings::GaussKronrod
-) where {Dim, T}
+) where {T}
     # Validate the provided integrand function
-    _validate_integrand(f,Dim,T)
+    _validate_integrand(f,2,T)
 
     # Integrate the box in parametric (u,v)-space
     innerintegral(u) = QuadGK.quadgk(v -> f(box(u,v)), 0, 1; settings.kwargs...)[1]

--- a/src/lineintegral.jl
+++ b/src/lineintegral.jl
@@ -97,7 +97,9 @@ function lineintegral(
     t(x) = 0.5x + 0.5
     point(x) = circle(t(x))
 
-    return length(circle) * sum(w .* f(point(x)) for (w,x) in zip(ws, xs))
+    # Integrate f along the circle's rim and apply a domain-correction
+    #   factor for [-1,1] ↦ [0, circumference]
+    return 0.5 * length(circle) * sum(w .* f(point(x)) for (w,x) in zip(ws, xs))
 end
 
 #=

--- a/src/lineintegral.jl
+++ b/src/lineintegral.jl
@@ -29,6 +29,16 @@ function lineintegral(
     return sum(segment -> lineintegral(f, segment, settings), segments(ring))
 end
 
+function lineintegral(
+    f::F,
+    disk::Meshes.Disk,
+    settings::I
+) where {F<:Function, I<:IntegrationAlgorithm}
+    # Disk is parametrically 2-dimensional
+    # Convert to a Circle, integrate that
+    return lineintegral(f, Circle(disk.plane, disk.radius), settings)
+end
+
 ################################################################################
 #                            Gauss-Legendre
 ################################################################################

--- a/src/lineintegral.jl
+++ b/src/lineintegral.jl
@@ -82,6 +82,24 @@ function lineintegral(
     return 0.5 * length(curve) * sum(w .* f(point(x)) for (w,x) in zip(ws, xs))
 end
 
+function lineintegral(
+    f::F,
+    circle::Meshes.Circle{T},
+    settings::GaussLegendre
+) where {F<:Function, T}
+    # Validate the provided integrand function
+    _validate_integrand(f,3,T)
+
+    # Compute Gauss-Legendre nodes/weights for x in interval [-1,1]
+    xs, ws = gausslegendre(settings.n)
+
+    # Change of variables: x [-1,1] ↦ t [0,1]
+    t(x) = 0.5x + 0.5
+    point(x) = circle(t(x))
+
+    return length(circle) * sum(w .* f(point(x)) for (w,x) in zip(ws, xs))
+end
+
 #=
 function lineintegral(
     f,
@@ -132,6 +150,19 @@ function lineintegral(
 
     len = length(curve)
     point(t) = curve(t, alg)
+    return QuadGK.quadgk(t -> len * f(point(t)), 0, 1; settings.kwargs...)[1]
+end
+
+function lineintegral(
+    f::F,
+    circle::Meshes.Circle{T},
+    settings::GaussKronrod
+) where {F<:Function, T}
+    # Validate the provided integrand function
+    _validate_integrand(f,3,T)
+
+    len = length(circle)
+    point(t) = circle(t)
     return QuadGK.quadgk(t -> len * f(point(t)), 0, 1; settings.kwargs...)[1]
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -46,6 +46,7 @@ function unitdirection(bz::Meshes.BezierCurve{Dim,T,V}, t) where {Dim,T,V}
     return u    # ::Vec{Dim,T}
 end
 
+#=
 """
     area(triangle::Meshes.Triangle)
 
@@ -60,3 +61,4 @@ function area(triangle::Meshes.Ngon{3,Dim,T}) where {Dim, T}
     s = (a + b + c) / 2
     return sqrt( s * (s-a) * (s-b) * (s-c) )
 end
+=#

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,20 +45,3 @@ function unitdirection(bz::Meshes.BezierCurve{Dim,T,V}, t) where {Dim,T,V}
     LinearAlgebra.normalize!(u)
     return u    # ::Vec{Dim,T}
 end
-
-#=
-"""
-    area(triangle::Meshes.Triangle)
-
-Calculate the un-signed area of a `triangle`.
-"""
-function area(triangle::Meshes.Ngon{3,Dim,T}) where {Dim, T}
-    # Use Heron's formula
-    A, B, C = triangle.vertices
-    a = norm(B-A)
-    b = norm(C-B)
-    c = norm(A-C)
-    s = (a + b + c) / 2
-    return sqrt( s * (s-a) * (s-b) * (s-c) )
-end
-=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ using Test
     # Triangle on upper-half-plane
     triangle = Ngon(pt_e, pt_n, pt_w)
 
-    for (name,rule) in [("Gauss-Legendre",GaussLegendre(100)), ("Gauss-Kronrod",GaussKronrod())]
+    for (name,rule) in [("Gauss-Legendre",GaussLegendre(1_000)), ("Gauss-Kronrod",GaussKronrod())]
         @testset "$name" begin
             @testset "Scalar-Valued Functions" begin
                 f(::Point) = 1.0
@@ -45,7 +45,7 @@ using Test
                 @test lineintegral(f, triangle, rule) ≈ 2 + 2sqrt(2)                  # Meshes.Triangle
 
                 # Surface Integrals
-                @test surfaceintegral(f, triangle, rule) ≈ 1.0           # Meshes.Triangle
+                @test isapprox(surfaceintegral(f, triangle, rule), 1.0; rtol=1e-3)     # Meshes.Triangle
             end
             @testset "Vector-Valued Functions" begin
                 f(::Point) = [1.0, 1.0, 1.0]
@@ -58,7 +58,7 @@ using Test
                 @test lineintegral(f, triangle, rule) ≈ (2 + 2sqrt(2)) .* [1.0, 1.0, 1.0]      # Meshes.Triangle
 
                 # Surface Integrals
-                @test surfaceintegral(f, triangle, rule) ≈ [1.0, 1.0, 1.0]           # Meshes.Triangle
+                @test isapprox(surfaceintegral(f, triangle, rule), [1.0, 1.0, 1.0]; rtol=1e-3)   # Meshes.Triangle
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ using Test
     # Triangle on upper-half-plane
     triangle = Ngon(pt_e, pt_n, pt_w)
 
-    for (name,rule) in [("Gauss-Legendre",GaussLegendre(1_000)), ("Gauss-Kronrod",GaussKronrod())]
+    for (name,rule) in [("Gauss-Legendre",GaussLegendre(10_000)), ("Gauss-Kronrod",GaussKronrod())]
         @testset "$name" begin
             @testset "Scalar-Valued Functions" begin
                 f(::Point) = 1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,20 +37,28 @@ using Test
         @testset "$name" begin
             @testset "Scalar-Valued Functions" begin
                 f(::Point) = 1.0
+                # Line Integrals
                 @test lineintegral(f, seg_ne, rule) ≈ sqrt(2)                         # Meshes.Segment
                 @test lineintegral(f, rect_traj_ring, rule) ≈ 4sqrt(2)                # Meshes.Ring
                 @test lineintegral(f, rect_traj_rope, rule) ≈ 4sqrt(2)                # Meshes.Rope
                 @test lineintegral(f, unit_circle, rule) ≈ length(unit_circle)        # Meshes.BezierCurve
-                #@test lineintegral(f, pt_e, pt_n, pt_w, pt_s, pt_e, rule) ≈ 4sqrt(2)  # Varargs of Meshes.Point
                 @test lineintegral(f, triangle, rule) ≈ 2 + 2sqrt(2)                  # Meshes.Triangle
+
+                # Surface Integrals
+                @test surfaceintegral(f, triangle, rule) ≈ 1.0           # Meshes.Triangle
             end
             @testset "Vector-Valued Functions" begin
                 f(::Point) = [1.0, 1.0, 1.0]
+
+                # Line Integrals
                 @test lineintegral(f, seg_ne, rule) ≈ [sqrt(2), sqrt(2), sqrt(2)]              # Meshes.Segment
                 @test lineintegral(f, rect_traj_ring, rule) ≈ [4sqrt(2), 4sqrt(2), 4sqrt(2)]   # Meshes.Ring
                 @test lineintegral(f, rect_traj_rope, rule) ≈ [4sqrt(2), 4sqrt(2), 4sqrt(2)]   # Meshes.Rope
                 @test lineintegral(f, unit_circle, rule) ≈ length(unit_circle) .* [1.0, 1.0, 1.0]    # Meshes.BezierCurve
                 @test lineintegral(f, triangle, rule) ≈ (2 + 2sqrt(2)) .* [1.0, 1.0, 1.0]      # Meshes.Triangle
+
+                # Surface Integrals
+                @test surfaceintegral(f, triangle, rule) ≈ [1.0, 1.0, 1.0]           # Meshes.Triangle
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,9 @@ using Test
     # Triangle on upper-half-plane
     triangle = Ngon(pt_e, pt_n, pt_w)
 
+    # 2D Box on [-1,1]^2
+    box2d = Box(Point(-1.0,-1.0), Point(1.0,1.0))
+
     for (name,rule) in [("Gauss-Legendre",GaussLegendre(10_000)), ("Gauss-Kronrod",GaussKronrod())]
         @testset "$name" begin
             @testset "Scalar-Valued Functions" begin
@@ -45,7 +48,8 @@ using Test
                 @test lineintegral(f, triangle, rule) ≈ 2 + 2sqrt(2)                  # Meshes.Triangle
 
                 # Surface Integrals
-                @test isapprox(surfaceintegral(f, triangle, rule), 1.0; rtol=1e-3)     # Meshes.Triangle
+                @test isapprox(surfaceintegral(f, triangle, rule), 1.0; rtol=1e-3)    # Meshes.Triangle
+                @test isapprox(surfaceintegral(f, box2d, rule), 4.0; rtol=1e-3)       # Meshes.Box{2,T}
             end
             @testset "Vector-Valued Functions" begin
                 f(::Point) = [1.0, 1.0, 1.0]
@@ -59,6 +63,7 @@ using Test
 
                 # Surface Integrals
                 @test isapprox(surfaceintegral(f, triangle, rule), [1.0, 1.0, 1.0]; rtol=1e-3)   # Meshes.Triangle
+                @test isapprox(surfaceintegral(f, box2d, rule), [4.0, 4.0, 4.0]; rtol=1e-3)      # Meshes.Box{2,T}
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,8 +35,9 @@ using Test
     # Triangle on upper-half-plane
     triangle = Ngon(pt_e, pt_n, pt_w)
 
-    # Unit circle
+    # Unit circle/disk
     unit_circle = Circle(Plane(origin,ẑ), 1.0)
+    unit_disk = Disk(Plane(origin,ẑ), 1.0)
 
     # 2D Box on [-1,1]^2
     box2d = Box(Point(-1.0,-1.0), Point(1.0,1.0))
@@ -51,11 +52,14 @@ using Test
                 @test lineintegral(f, rect_traj_rope, rule) ≈ 4sqrt(2)                # Meshes.Rope
                 @test lineintegral(f, unit_bezier, rule) ≈ length(unit_bezier)        # Meshes.BezierCurve
                 @test lineintegral(f, unit_circle, rule) ≈ length(unit_circle)        # Meshes.Circle
+                @test lineintegral(f, unit_disk, rule) ≈ length(unit_circle)          # Meshes.Disk
                 @test lineintegral(f, triangle, rule) ≈ 2 + 2sqrt(2)                  # Meshes.Triangle
 
                 # Surface Integrals
                 @test isapprox(surfaceintegral(f, triangle, rule), 1.0; rtol=1e-3)    # Meshes.Triangle
                 @test isapprox(surfaceintegral(f, box2d, rule), 4.0; rtol=1e-3)       # Meshes.Box{2,T}
+                @test isapprox(surfaceintegral(f, unit_circle, rule), area(unit_disk); rtol=1e-3)   # Meshes.Circle
+                @test isapprox(surfaceintegral(f, unit_disk, rule), area(unit_disk); rtol=1e-3)     # Meshes.Disk
             end
             @testset "Vector-Valued Functions" begin
                 f(::Point) = [1.0, 1.0, 1.0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,8 @@ using Test
     pt_n = Point( 0.0,  1.0, 0.0)
     pt_w = Point(-1.0,  0.0, 0.0)
     pt_s = Point( 0.0, -1.0, 0.0)
+    origin = Point(0.0, 0.0, 0.0)
+    ẑ = Vec(0.0, 0.0, 1.0)
 
     # Line segments oriented CCW between points
     seg_ne = Segment(pt_e, pt_n)
@@ -26,12 +28,15 @@ using Test
     rect_traj_rope = Rope(pt_e, pt_n, pt_w, pt_s, pt_e)
 
     # Approximately circular trajectory CCW around the unit circle
-    unit_circle = BezierCurve(
+    unit_bezier = BezierCurve(
         [Point(cos(t), sin(t), 0.0) for t in range(0, 2pi, length=361)]
     )
 
     # Triangle on upper-half-plane
     triangle = Ngon(pt_e, pt_n, pt_w)
+
+    # Unit circle
+    unit_circle = Circle(Plane(origin,ẑ), 1.0)
 
     # 2D Box on [-1,1]^2
     box2d = Box(Point(-1.0,-1.0), Point(1.0,1.0))
@@ -44,7 +49,8 @@ using Test
                 @test lineintegral(f, seg_ne, rule) ≈ sqrt(2)                         # Meshes.Segment
                 @test lineintegral(f, rect_traj_ring, rule) ≈ 4sqrt(2)                # Meshes.Ring
                 @test lineintegral(f, rect_traj_rope, rule) ≈ 4sqrt(2)                # Meshes.Rope
-                @test lineintegral(f, unit_circle, rule) ≈ length(unit_circle)        # Meshes.BezierCurve
+                @test lineintegral(f, unit_bezier, rule) ≈ length(unit_bezier)        # Meshes.BezierCurve
+                @test lineintegral(f, unit_circle, rule) ≈ length(unit_circle)        # Meshes.Circle
                 @test lineintegral(f, triangle, rule) ≈ 2 + 2sqrt(2)                  # Meshes.Triangle
 
                 # Surface Integrals
@@ -58,7 +64,8 @@ using Test
                 @test lineintegral(f, seg_ne, rule) ≈ [sqrt(2), sqrt(2), sqrt(2)]              # Meshes.Segment
                 @test lineintegral(f, rect_traj_ring, rule) ≈ [4sqrt(2), 4sqrt(2), 4sqrt(2)]   # Meshes.Ring
                 @test lineintegral(f, rect_traj_rope, rule) ≈ [4sqrt(2), 4sqrt(2), 4sqrt(2)]   # Meshes.Rope
-                @test lineintegral(f, unit_circle, rule) ≈ length(unit_circle) .* [1.0, 1.0, 1.0]    # Meshes.BezierCurve
+                @test lineintegral(f, unit_bezier, rule) ≈ length(unit_bezier) .* [1.0, 1.0, 1.0]    # Meshes.BezierCurve
+                @test lineintegral(f, unit_circle, rule) ≈ length(unit_circle) .* [1.0, 1.0, 1.0]    # Meshes.Circle
                 @test lineintegral(f, triangle, rule) ≈ (2 + 2sqrt(2)) .* [1.0, 1.0, 1.0]      # Meshes.Triangle
 
                 # Surface Integrals


### PR DESCRIPTION
Updates:
- Adds `lineintegral` methods for `Circle` and `Disk`
- Adds `surfaceintegral` methods for `Circle` and `Disk`
- Clarifies in support matrix which methods require implicit conversion (#5)

Note: some commits from previous 0.8.x branch that were previously squashed+merged to main were accidentally pushed and show up redundantly in this branch.