### PR TITLE
Add lineintegral methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeshIntegrals"
 uuid = "dadec2fd-bbe0-4da4-9dbe-476c782c8e47"
 authors = ["Mike Ingold <mike.ingold@gmail.com>"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeshIntegrals"
 uuid = "dadec2fd-bbe0-4da4-9dbe-476c782c8e47"
 authors = ["Mike Ingold <mike.ingold@gmail.com>"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Methods are tested to ensure compatibility with
 | Geometry | Gauss-Legendre | Gauss-Kronrod |
 |----------|----------------|---------------|
 | `Meshes.BezierCurve` | :white_check_mark: | :white_check_mark: |
-| `Meshes.Box{1,T}` | :x: | :x: |
+| `Meshes.Box{1,T}` | :yellow_square: | :yellow_square: |
 | `Meshes.Circle` | :white_check_mark: | :white_check_mark: |
-| `Meshes.Line` | :x: | :x: |
+| `Meshes.Line` | :yellow_square: | :yellow_square: |
 | `Meshes.Ring` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Rope` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Segment` | :white_check_mark: | :white_check_mark: |
@@ -91,6 +91,7 @@ fr(p) = fr(p.coords...)
     - Re-implement all tests for Unitful compatibility
 
 - Longer term:
+    - Once all methods are implemented, determine which can be consolidated with a more abstract/unioned case
     - Implement Aqua.jl tests
     - Implement Documenter docs
     - Implement Monte Carlo integration methods

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Methods are tested to ensure compatibility with
 | Geometry | Gauss-Legendre | Gauss-Kronrod |
 |----------|----------------|---------------|
 | `Meshes.BezierCurve` | :white_check_mark: | :white_check_mark: |
-| `Meshes.Box{1,T}` | :yellow_square: | :yellow_square: |
+| `Meshes.Box{1,T}` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Circle` | :white_check_mark: | :white_check_mark: |
-| `Meshes.Line` | :yellow_square: | :yellow_square: |
+| `Meshes.Line` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Ring` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Rope` | :white_check_mark: | :white_check_mark: |
 | `Meshes.Segment` | :white_check_mark: | :white_check_mark: |
@@ -70,7 +70,7 @@ unit_circle = BezierCurve(
 fr(x,y,z) = abs(x + y)
 fr(p) = fr(p.coords...)
 
-@btime lineintegral(fr, unit_circle, GaussLegendre(100))
+@btime lineintegral(fr, unit_circle)
     # 9.970 ms (18831 allocations: 78.40 MiB)
     # 5.55240987912083
 

--- a/src/integral_line.jl
+++ b/src/integral_line.jl
@@ -98,6 +98,25 @@ end
 
 function lineintegral(
     f::F,
+    line::Meshes.Line{Dim,T},
+    settings::GaussLegendre
+) where {F<:Function, Dim, T}
+    # Validate the provided integrand function
+    _validate_integrand(f,Dim,T)
+
+    # Compute Gauss-Legendre nodes/weights for x in interval [-1,1]
+    xs, ws = gausslegendre(settings.n)
+
+    # Change of variables: x [-1,1] ↦ t [0,1]
+    t(x) = 0.5x + 0.5
+    point(x) = line(t(x))
+
+    # Integrate f along the line and apply a domain-correction factor for [-1,1] ↦ [0, length]
+    return 0.5 * length(line) * sum(w .* f(point(x)) for (w,x) in zip(ws, xs))
+end
+
+function lineintegral(
+    f::F,
     segment::Meshes.Segment{Dim,T},
     settings::GaussLegendre
 ) where {F<:Function, Dim, T}
@@ -190,6 +209,19 @@ function lineintegral(
 
     len = length(circle)
     point(t) = circle(t)
+    return QuadGK.quadgk(t -> len * f(point(t)), 0, 1; settings.kwargs...)[1]
+end
+
+function lineintegral(
+    f::F,
+    line::Meshes.Line{Dim,T},
+    settings::GaussKronrod
+) where {F<:Function, Dim, T}
+    # Validate the provided integrand function
+    _validate_integrand(f,Dim,T)
+
+    len = length(line)
+    point(t) = line(t)
     return QuadGK.quadgk(t -> len * f(point(t)), 0, 1; settings.kwargs...)[1]
 end
 

--- a/src/integral_line.jl
+++ b/src/integral_line.jl
@@ -107,12 +107,11 @@ function lineintegral(
     # Compute Gauss-Legendre nodes/weights for x in interval [-1,1]
     xs, ws = gausslegendre(settings.n)
 
-    # Change of variables: x [-1,1] ↦ t [0,1]
-    t(x) = 0.5x + 0.5
-    point(x) = line(t(x))
+    # Change of variables: t [-Inf,Inf] ↦ x [-1,1]
+    integrand(x) = f(line((x/(1-x^2)))) * (1+x^2)/((1-x^2)^2)
 
-    # Integrate f along the line and apply a domain-correction factor for [-1,1] ↦ [0, length]
-    return 0.5 * length(line) * sum(w .* f(point(x)) for (w,x) in zip(ws, xs))
+    # Integrate f along the line
+    return sum(w .* integrand(x) for (w,x) in zip(ws, xs))
 end
 
 function lineintegral(
@@ -220,9 +219,8 @@ function lineintegral(
     # Validate the provided integrand function
     _validate_integrand(f,Dim,T)
 
-    len = length(line)
-    point(t) = line(t)
-    return QuadGK.quadgk(t -> len * f(point(t)), 0, 1; settings.kwargs...)[1]
+    # Lines are infinite-length passing through defined points a and b
+    return QuadGK.quadgk(t -> f(line(t)), -Inf, Inf; settings.kwargs...)[1]
 end
 
 function lineintegral(

--- a/src/integral_line.jl
+++ b/src/integral_line.jl
@@ -57,6 +57,26 @@ end
 
 function lineintegral(
     f::F,
+    line::Meshes.Box{1,T},
+    settings::GaussLegendre
+) where {F<:Function, T}
+    # Validate the provided integrand function
+    # A Box{1,T} is definitionally embedded in 1D-space
+    _validate_integrand(f,1,T)
+
+    # Compute Gauss-Legendre nodes/weights for x in interval [-1,1]
+    xs, ws = gausslegendre(settings.n)
+
+    # Change of variables: x [-1,1] ↦ t [0,1]
+    t(x) = 0.5x + 0.5
+    point(x) = line(t(x))
+
+    # Integrate f along the line and apply a domain-correction factor for [-1,1] ↦ [0, length]
+    return 0.5 * length(line) * sum(w .* f(point(x)) for (w,x) in zip(ws, xs))
+end
+
+function lineintegral(
+    f::F,
     circle::Meshes.Circle{T},
     settings::GaussLegendre
 ) where {F<:Function, T}
@@ -142,6 +162,20 @@ function lineintegral(
 
     len = length(curve)
     point(t) = curve(t, alg)
+    return QuadGK.quadgk(t -> len * f(point(t)), 0, 1; settings.kwargs...)[1]
+end
+
+function lineintegral(
+    f::F,
+    line::Meshes.Box{1,T},
+    settings::GaussKronrod
+) where {F<:Function, T}
+    # Validate the provided integrand function
+    # A Box is definitionally embedded in 1D-space
+    _validate_integrand(f,1,T)
+
+    len = length(line)
+    point(t) = line(t)
     return QuadGK.quadgk(t -> len * f(point(t)), 0, 1; settings.kwargs...)[1]
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,7 +79,9 @@ using Test
                 f(::Point) = 1.0
                 # Line Integrals
                 @test lineintegral(f, bezier, rule) ≈ length(bezier)        # BezierCurve
+                @test lineintegral(f, box1d, rule) ≈ length(box1d)          # Box{1,T}
                 @test lineintegral(f, circle, rule) ≈ length(circle)        # Circle
+                @test lineintegral(f, line_ne, rule) ≈ length(line_ne)      # Line
                 @test lineintegral(f, ring_rect, rule) ≈ length(ring_rect)  # Ring
                 @test lineintegral(f, rope_rect, rule) ≈ length(rope_rect)  # Rope
                 @test lineintegral(f, seg_ne, rule) ≈ length(seg_ne)        # Segment
@@ -95,7 +97,9 @@ using Test
 
                 # Line Integrals
                 @test lineintegral(f, bezier, rule) ≈ fill(length(bezier),3)         # BezierCurve
+                @test lineintegral(f, box1d, rule) ≈ fill(length(box1d),3)           # Box{1,T}
                 @test lineintegral(f, circle, rule) ≈ fill(length(circle),3)         # Circle
+                @test lineintegral(f, line_ne, rule) ≈ fill(length(line_ne),3)       # Line
                 @test lineintegral(f, ring_rect, rule) ≈ fill(length(ring_rect),3)   # Ring
                 @test lineintegral(f, rope_rect, rule) ≈ fill(length(rope_rect),3)   # Rope
                 @test lineintegral(f, seg_ne, rule) ≈ fill(length(seg_ne),3)         # Segment

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,11 +77,14 @@ using Test
         @testset "$name" begin
             @testset "Scalar-Valued Functions" begin
                 f(::Point) = 1.0
+                fLine(p::Point) = exp(-(p.coords[1])^2)
+                fLineVal = sqrt(pi) * sqrt(2)
+
                 # Line Integrals
                 @test lineintegral(f, bezier, rule) ≈ length(bezier)        # BezierCurve
                 @test lineintegral(f, box1d, rule) ≈ length(box1d)          # Box{1,T}
                 @test lineintegral(f, circle, rule) ≈ length(circle)        # Circle
-                @test lineintegral(f, line_ne, rule) ≈ length(line_ne)      # Line
+                @test lineintegral(fLine, line_ne, rule) ≈ fLineVal         # Line
                 @test lineintegral(f, ring_rect, rule) ≈ length(ring_rect)  # Ring
                 @test lineintegral(f, rope_rect, rule) ≈ length(rope_rect)  # Rope
                 @test lineintegral(f, seg_ne, rule) ≈ length(seg_ne)        # Segment
@@ -94,12 +97,14 @@ using Test
             end
             @testset "Vector-Valued Functions" begin
                 f(::Point) = [1.0, 1.0, 1.0]
+                fLine(p::Point) = fill(exp(-(p.coords[1])^2), 3)
+                fLineVal = sqrt(pi) * sqrt(2)
 
                 # Line Integrals
                 @test lineintegral(f, bezier, rule) ≈ fill(length(bezier),3)         # BezierCurve
                 @test lineintegral(f, box1d, rule) ≈ fill(length(box1d),3)           # Box{1,T}
                 @test lineintegral(f, circle, rule) ≈ fill(length(circle),3)         # Circle
-                @test lineintegral(f, line_ne, rule) ≈ fill(length(line_ne),3)       # Line
+                @test lineintegral(fLine, line_ne, rule) ≈ fill(fLineVal,3)          # Line
                 @test lineintegral(f, ring_rect, rule) ≈ fill(length(ring_rect),3)   # Ring
                 @test lineintegral(f, rope_rect, rule) ≈ fill(length(rope_rect),3)   # Rope
                 @test lineintegral(f, seg_ne, rule) ≈ fill(length(seg_ne),3)         # Segment

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,7 +78,7 @@ using Test
             @testset "Scalar-Valued Functions" begin
                 f(::Point) = 1.0
                 fLine(p::Point) = exp(-(p.coords[1])^2)
-                fLineVal = sqrt(pi) * sqrt(2)
+                fLineVal = sqrt(pi)
 
                 # Line Integrals
                 @test lineintegral(f, bezier, rule) ≈ length(bezier)        # BezierCurve
@@ -98,7 +98,7 @@ using Test
             @testset "Vector-Valued Functions" begin
                 f(::Point) = [1.0, 1.0, 1.0]
                 fLine(p::Point) = fill(exp(-(p.coords[1])^2), 3)
-                fLineVal = sqrt(pi) * sqrt(2)
+                fLineVal = sqrt(pi)
 
                 # Line Integrals
                 @test lineintegral(f, bezier, rule) ≈ fill(length(bezier),3)         # BezierCurve


### PR DESCRIPTION
Updates:
- Adds `lineintegral` methods for `Box{1,T}` and `Line`