### PR TITLE
Add `SimpleMesh` to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Methods are tested to ensure compatibility with
 | `Meshes.Sphere{3,T}` | :x: | :x: | :x: |
 | `Meshes.Triangle` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `Meshes.Torus` | :x: | :x: | :x: |
+| `Meshes.SimpleMesh` | :x: | :x: | :x: |
 
 ### Volume Integrals
 | Geometry | Gauss-Legendre | H-Adaptive Cubature |


### PR DESCRIPTION
It is great to see numerical packages being built on top of `Meshes.jl`. I already have plans where I can use this in the future, but that really requires being able to integrate over a `SimpleMesh`. I am pretty tied up right now, but I'm trying to stay in the loop on this package and can contribute in a few months when I free up some time. Great work.