### PR TITLE
Add badges for coverage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # MeshIntegrals.jl
 
 [![Build Status](https://github.com/mikeingold/MeshIntegrals.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/mikeingold/MeshIntegrals.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![codecov](https://codecov.io/gh/mikeingold/MeshIntegrals.jl/graph/badge.svg)](https://codecov.io/gh/mikeingold/MeshIntegrals.jl)
+[![Coveralls](https://coveralls.io/repos/github/mikeingold/MeshIntegrals.jl/badge.svg?branch=main)](https://coveralls.io/github/mikeingold/MeshIntegrals.jl?branch=main)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 [![License: MIT](https://img.shields.io/badge/License-MIT-success.svg)](https://opensource.org/licenses/MIT)
 

--- a/src/MeshIntegrals.jl
+++ b/src/MeshIntegrals.jl
@@ -18,4 +18,5 @@ module MeshIntegrals
     include("integral_volume.jl")
     export GaussKronrod, GaussLegendre, HAdaptiveCubature
     export integral, lineintegral, surfaceintegral, volumeintegral
+
 end

--- a/src/MeshIntegrals.jl
+++ b/src/MeshIntegrals.jl
@@ -18,5 +18,4 @@ module MeshIntegrals
     include("integral_volume.jl")
     export GaussKronrod, GaussLegendre, HAdaptiveCubature
     export integral, lineintegral, surfaceintegral, volumeintegral
-
 end


### PR DESCRIPTION
Now that we have CI and coverage running, we can add the badges indicating the code coverage and linking to the respective pages to the README.
(This is also meant as a test PR to see if CI runs in a PR now)