### PR TITLE
Add TagBot.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,7 @@ on:
       - 'README.md'
       - '.github/workflows/CompatHelper.yml'
       - '.github/workflows/SpellCheck.yml'
+      - '.github/workflows/TagBot.yml'
       - 'docs/**'
   pull_request:
     paths-ignore:
@@ -16,6 +17,7 @@ on:
       - 'README.md'
       - '.github/workflows/CompatHelper.yml'
       - '.github/workflows/SpellCheck.yml'
+      - '.github/workflows/TagBot.yml'
       - 'docs/**'
   workflow_dispatch:
 

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
I noticed that there is no tag bot used, i.e. you manually create a tag after registering a new version of the package. The tag bot is widely used for Julia packages to automatically create a new tag once the register PR in General is merged. This way consistency between the registry in General and the actual registered versions is guaranteed and you don't need to manually create a new tag. I think it's generally considered good practice to have tag bot running and thus it would be nice to also have it here.
See https://github.com/JuliaRegistries/TagBot.