### PR TITLE
More unit test improvements (#73)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeshIntegrals"
 uuid = "dadec2fd-bbe0-4da4-9dbe-476c782c8e47"
 authors = ["Mike Ingold <mike.ingold@gmail.com>"]
-version = "0.13.3"
+version = "0.13.4"
 
 [deps]
 CoordRefSystems = "b46f11dc-f210-4604-bfba-323c1ec968cb"

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -55,6 +55,16 @@ end
 Numerically integrate a given function `f(::Point)` over the domain defined by
 a `geometry` using a particular `integration algorithm` with floating point
 precision of type `FP`.
+
+# Arguments
+- `f`: an integrand function with a method `f(::Meshes.Point)`
+- `geometry`: some `Meshes.Geometry` that defines the integration domain
+- `algorithm`: optionally, the `IntegrationAlgorithm` used for the integration (by default `GaussKronrod()` in 1D and `HAdaptiveCubature()` else)
+- `FP`: optionally, the floating point precision desired (`Float64` by default)
+
+Note that reducing `FP` below `Float64` will incur some loss of precision. By
+contrast, increasing `FP` to e.g. `BigFloat` will typically increase precision
+(at the expense of longer runtimes).
 """
 function integral end
 


### PR DESCRIPTION
* Add new tests for Segment

* Bump patch version

* Add test verbose and showtimings

* Complete TODO action

* Add tests for alternate FP types

* Fix typo and add more alt FP test coverage

* Fix typo

* Bugfix

* Bugfix - missing N for Gauss-Legendre rules

* Bugfix - missing unit exponents

* Mark type tests broken, named f32, increase GL rule N

* Fix typo

* Reduce N for GL rules, add looser atol's for F32 results

* Tweak tolerances

* Split tests into new set [skip ci]

* Implement new tests for Rope

* Bugfix

* Math correction

* Add new tests for Ring

* Bugfixes

* Bugfix

* Remove Ring from old tests

* Bugfix

* Reorganize alt FP tests

* Fix atol value, abstract testset with a loop

* Remove unnecessary begin

* Abstract FP type, split aliases into separate set

* Update types

* Add BigFloat tests

* Conditional broken statement

* Enhance integral docstring, add sub-FP64 warning

* Improved argument explanation



* Drop an explicit showtimings



* Remove redundant showtimings

* Add a type-dependent atol

* Add note about BigFloat

---------