### PR TITLE
Breaking changes targeting v0.14

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MeshIntegrals"
 uuid = "dadec2fd-bbe0-4da4-9dbe-476c782c8e47"
-version = "0.13.5"
+version = "0.14.0-DEV"
 
 [deps]
 CoordRefSystems = "b46f11dc-f210-4604-bfba-323c1ec968cb"


### PR DESCRIPTION
Several significant breaking changes are planned for this major version. Some of these changes may be implemented in sub-branches and then merged into this one for ease of review.

## Plans

### Branch: breaking-rules

- Rename `IntegrationAlgorithm` to `IntegrationRule`, change references from "algorithm", "settings", etc to "rule"

### Others

- Convert `FP` to a keyword argument.
  - Figure out how to ensure clean pass-through of arguments from alias functions, e.g. `lineintegral` -> `integral` -> `_integral`?
- Add "Why Specialized" lines to each specialization source file: why does this geometry require specialized methods vs the generalized ones?
- Remove `jacobian`, `derivative`, and `unitdirection` from exports -- these originated when the package's trajectory was less clear, and behave more like interesting internal tools