### PR TITLE
v0.14-DEV: Remove `derivative` and `unitdirection` from exports

### DIFF
--- a/src/MeshIntegrals.jl
+++ b/src/MeshIntegrals.jl
@@ -9,7 +9,6 @@ import HCubature
 import QuadGK
 
 include("utils.jl")
-export jacobian, derivative, unitdirection
 
 include("integration_rules.jl")
 export IntegrationRule, GaussKronrod, GaussLegendre, HAdaptiveCubature

--- a/src/MeshIntegrals.jl
+++ b/src/MeshIntegrals.jl
@@ -9,6 +9,7 @@ import HCubature
 import QuadGK
 
 include("utils.jl")
+export jacobian
 
 include("integration_rules.jl")
 export IntegrationRule, GaussKronrod, GaussLegendre, HAdaptiveCubature


### PR DESCRIPTION
## Completed
- Removed `derivative` and `unitdirection` from exports. These functions were developed early on when the direction of this package wasn't fully clear, and only `BezierCurve`-specific methods were added. In the long-term, I'd like to implement a more robust system for calculating derivatives and Jacobians, ideally using automatic differentiation. I'm removing these from the public API to facilitate future experimentation but won't remove them from the package entirely.