### PR TITLE
Implement `differential` and `jacobian` for Bezier curve integrals

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,3 +21,9 @@ MeshIntegrals.GaussKronrod
 MeshIntegrals.GaussLegendre
 MeshIntegrals.HAdaptiveCubature
 ```
+
+## Derivatives
+
+```@docs
+MeshIntegrals.jacobian
+```

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -104,9 +104,9 @@ Calculate the differential element (length, area, volume, etc) of the parametric
 function for `geometry` at arguments `ts`.
 """
 function differential(
-        geometry,
-        ts
-)
+        geometry::G,
+        ts::V
+) where {G <: Meshes.Geometry, V <: Union{AbstractVector, Tuple}}
     J = jacobian(geometry, ts)
 
     # TODO generalize this with geometric algebra, e.g.: norm(foldl(∧, J))

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -64,8 +64,8 @@ function jacobian(
 end
 
 function jacobian(
-    bz::Meshes.BezierCurve,
-    ts::V
+        bz::Meshes.BezierCurve,
+        ts::V
 ) where {V <: Union{AbstractVector, Tuple}}
     # Parameter t restricted to domain [0,1] by definition
     if t < 0 || t > 1
@@ -119,8 +119,3 @@ function differential(
         error("Not implemented yet. Please report this as an Issue on GitHub.")
     end
 end
-
-
-
-
-

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -87,14 +87,14 @@ function _integral(
 ) where {T <: AbstractFloat}
     N = Meshes.paramdim(geometry)
 
-    integrand(t) = f(geometry(t...)) * differential(geometry, t)
+    integrand(ts) = f(geometry(ts...)) * differential(geometry, ts)
 
     # HCubature doesn't support functions that output Unitful Quantity types
     # Establish the units that are output by f
     testpoint_parametriccoord = zeros(FP, N)
     integrandunits = Unitful.unit.(integrand(testpoint_parametriccoord))
     # Create a wrapper that returns only the value component in those units
-    uintegrand(uv) = Unitful.ustrip.(integrandunits, integrand(uv))
+    uintegrand(ts) = Unitful.ustrip.(integrandunits, integrand(ts))
     # Integrate only the unitless values
     value = HCubature.hcubature(uintegrand, zeros(FP, N), ones(FP, N); rule.kwargs...)[1]
 

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -112,7 +112,7 @@ function _integral_gk_1d(
         rule::GaussKronrod;
         FP::Type{T} = Float64
 ) where {T <: AbstractFloat}
-    integrand(t) = f(geometry(t)) * differential(geometry, (t))
+    integrand(t) = f(geometry(t)) * differential(geometry, (t,))
     return QuadGK.quadgk(integrand, zero(FP), one(FP); rule.kwargs...)[1]
 end
 

--- a/src/specializations/BezierCurve.jl
+++ b/src/specializations/BezierCurve.jl
@@ -86,7 +86,7 @@ function integral(
 
     # HCubature doesn't support functions that output Unitful Quantity types
     # Establish the units that are output by f
-    testpoint_parametriccoord = zeros(FP, 3)
+    testpoint_parametriccoord = zeros(FP, 1)
     integrandunits = Unitful.unit.(integrand(testpoint_parametriccoord))
     # Create a wrapper that returns only the value component in those units
     uintegrand(uv) = Unitful.ustrip.(integrandunits, integrand(uv))

--- a/test/auto_tests.jl
+++ b/test/auto_tests.jl
@@ -83,7 +83,6 @@ end
     # Test Geometries
     ball2d(T) = Ball(origin2d(T), T(2.0))
     ball3d(T) = Ball(origin3d(T), T(2.0))
-    bezier(T) = BezierCurve([Point(cos(t), sin(t), 0) for t in T(0):T(0.1):T(2π)])
     box1d(T) = Box(Point(T(-1)), Point(T(1)))
     box2d(T) = Box(Point(T(-1), T(-1)), Point(T(1), T(1)))
     box3d(T) = Box(Point(T(-1), T(-1), T(-1)), Point(T(1), T(1), T(-1)))
@@ -102,7 +101,6 @@ end
         # Name, T type, example,    integral,line,surface,volume,    GaussLegendre,GaussKronrod,HAdaptiveCubature
         SupportItem("Ball{2,$T}", T, ball2d(T), 1, 0, 1, 0, 1, 1, 1),
         SupportItem("Ball{3,$T}", T, ball3d(T), 1, 0, 0, 1, 1, 0, 1),
-        SupportItem("BezierCurve{$T}", T, bezier(T), 1, 1, 0, 0, 1, 1, 1),
         SupportItem("Box{1,$T}", T, box1d(T), 1, 1, 0, 0, 1, 1, 1),
         SupportItem("Box{2,$T}", T, box2d(T), 1, 0, 1, 0, 1, 1, 1),
         SupportItem("Box{3,$T}", T, box3d(T), 1, 0, 0, 1, 1, 0, 1),

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -2,6 +2,33 @@
 # - All supported combinations of integral(f, ::Geometry, ::IntegrationAlgorithm) produce accurate results
 # - Invalid applications of integral aliases (e.g. lineintegral) produce a descriptive error
 
+@testitem "Meshes.BezierCurve" setup=[Setup] begin
+    mypath = BezierCurve(
+        [Point(t*u"m", sin(t)*u"m", 0.0u"m") for t in range(-pi, pi, length=361)]
+    )
+
+    f(x, y, z) = (1 / sqrt(1 + cos(x)^2)) * u"Ω/m"
+    f(p::Meshes.Point) = f(ustrip(to(p))...)
+    fv(p) = fill(f(p), 3)
+
+    # Scalar integrand
+    sol = 2π * u"Ω"
+    @test integral(f, line, GaussLegendre(100)) ≈ sol
+    @test integral(f, line, GaussKronrod()) ≈ sol
+    @test integral(f, line, HAdaptiveCubature()) ≈ sol
+
+    # Vector integrand
+    vsol = fill(sol, 3)
+    @test integral(fv, line, GaussLegendre(100)) ≈ vsol
+    @test integral(fv, line, GaussKronrod()) ≈ vsol
+    @test integral(fv, line, HAdaptiveCubature()) ≈ vsol
+
+    # Integral aliases
+    @test lineintegral(f, line) ≈ sol
+    @test_throws "not supported" surfaceintegral(f, line)
+    @test_throws "not supported" volumeintegral(f, line)
+end
+
 @testitem "Meshes.Cone" setup=[Setup] begin
     r = 2.5u"m"
     h = 2.5u"m"

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -3,7 +3,7 @@
 # - Invalid applications of integral aliases (e.g. lineintegral) produce a descriptive error
 
 @testitem "Meshes.BezierCurve" setup=[Setup] begin
-    mypath = BezierCurve(
+    curve = BezierCurve(
         [Point(t * u"m", sin(t) * u"m", 0.0u"m") for t in range(-pi, pi, length = 361)]
     )
 

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -3,7 +3,7 @@
 # - Invalid applications of integral aliases (e.g. lineintegral) produce a descriptive error
 
 @testitem "Meshes.BezierCurve" setup=[Setup] begin
-    mypath = BezierCurve(
+    curve = BezierCurve(
         [Point(t*u"m", sin(t)*u"m", 0.0u"m") for t in range(-pi, pi, length=361)]
     )
 
@@ -13,20 +13,20 @@
 
     # Scalar integrand
     sol = 2π * u"Ω"
-    @test integral(f, line, GaussLegendre(100)) ≈ sol
-    @test integral(f, line, GaussKronrod()) ≈ sol
-    @test integral(f, line, HAdaptiveCubature()) ≈ sol
+    @test integral(f, curve, GaussLegendre(100)) ≈ sol
+    @test integral(f, curve, GaussKronrod()) ≈ sol
+    @test integral(f, curve, HAdaptiveCubature()) ≈ sol
 
     # Vector integrand
     vsol = fill(sol, 3)
-    @test integral(fv, line, GaussLegendre(100)) ≈ vsol
-    @test integral(fv, line, GaussKronrod()) ≈ vsol
-    @test integral(fv, line, HAdaptiveCubature()) ≈ vsol
+    @test integral(fv, curve, GaussLegendre(100)) ≈ vsol
+    @test integral(fv, curve, GaussKronrod()) ≈ vsol
+    @test integral(fv, curve, HAdaptiveCubature()) ≈ vsol
 
     # Integral aliases
-    @test lineintegral(f, line) ≈ sol
-    @test_throws "not supported" surfaceintegral(f, line)
-    @test_throws "not supported" volumeintegral(f, line)
+    @test lineintegral(f, curve) ≈ sol
+    @test_throws "not supported" surfaceintegral(f, curve)
+    @test_throws "not supported" volumeintegral(f, curve)
 end
 
 @testitem "Meshes.Cone" setup=[Setup] begin

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -13,18 +13,18 @@
 
     # Scalar integrand
     sol = 2π * u"Ω"
-    @test integral(f, curve, GaussLegendre(100)) ≈ sol
-    @test integral(f, curve, GaussKronrod()) ≈ sol
-    @test integral(f, curve, HAdaptiveCubature()) ≈ sol
+    @test integral(f, curve, GaussLegendre(100))≈sol rtol=1e-3
+    @test integral(f, curve, GaussKronrod())≈sol rtol=1e-3
+    @test integral(f, curve, HAdaptiveCubature())≈sol rtol=1e-3
 
     # Vector integrand
     vsol = fill(sol, 3)
-    @test integral(fv, curve, GaussLegendre(100)) ≈ vsol
-    @test integral(fv, curve, GaussKronrod()) ≈ vsol
-    @test integral(fv, curve, HAdaptiveCubature()) ≈ vsol
+    @test integral(fv, curve, GaussLegendre(100))≈vsol rtol=1e-3
+    @test integral(fv, curve, GaussKronrod())≈vsol rtol=1e-3
+    @test integral(fv, curve, HAdaptiveCubature())≈vsol rtol=1e-3
 
     # Integral aliases
-    @test lineintegral(f, curve) ≈ sol
+    @test lineintegral(f, curve)≈sol rtol=1e-3
     @test_throws "not supported" surfaceintegral(f, curve)
     @test_throws "not supported" volumeintegral(f, curve)
 end

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -13,18 +13,18 @@
 
     # Scalar integrand
     sol = 2π * u"Ω"
-    @test integral(f, curve, GaussLegendre(100))≈sol rtol=1e-3
-    @test integral(f, curve, GaussKronrod())≈sol rtol=1e-3
-    @test integral(f, curve, HAdaptiveCubature())≈sol rtol=1e-3
+    @test integral(f, curve, GaussLegendre(100))≈sol rtol=0.05e-2
+    @test integral(f, curve, GaussKronrod())≈sol rtol=0.05e-2
+    @test integral(f, curve, HAdaptiveCubature())≈sol rtol=0.05e-2
 
     # Vector integrand
     vsol = fill(sol, 3)
-    @test integral(fv, curve, GaussLegendre(100))≈vsol rtol=1e-3
-    @test integral(fv, curve, GaussKronrod())≈vsol rtol=1e-3
-    @test integral(fv, curve, HAdaptiveCubature())≈vsol rtol=1e-3
+    @test integral(fv, curve, GaussLegendre(100))≈vsol rtol=0.05e-2
+    @test integral(fv, curve, GaussKronrod())≈vsol rtol=0.05e-2
+    @test integral(fv, curve, HAdaptiveCubature())≈vsol rtol=0.05e-2
 
     # Integral aliases
-    @test lineintegral(f, curve)≈sol rtol=1e-3
+    @test lineintegral(f, curve)≈sol rtol=0.05e-2
     @test_throws "not supported" surfaceintegral(f, curve)
     @test_throws "not supported" volumeintegral(f, curve)
 end

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -13,18 +13,18 @@
 
     # Scalar integrand
     sol = 2π * u"Ω"
-    @test integral(f, curve, GaussLegendre(100))≈sol rtol=0.05e-2
-    @test integral(f, curve, GaussKronrod())≈sol rtol=0.05e-2
-    @test integral(f, curve, HAdaptiveCubature())≈sol rtol=0.05e-2
+    @test integral(f, curve, GaussLegendre(100))≈sol rtol=0.5e-2
+    @test integral(f, curve, GaussKronrod())≈sol rtol=0.5e-2
+    @test integral(f, curve, HAdaptiveCubature())≈sol rtol=0.5e-2
 
     # Vector integrand
     vsol = fill(sol, 3)
-    @test integral(fv, curve, GaussLegendre(100))≈vsol rtol=0.05e-2
-    @test integral(fv, curve, GaussKronrod())≈vsol rtol=0.05e-2
-    @test integral(fv, curve, HAdaptiveCubature())≈vsol rtol=0.05e-2
+    @test integral(fv, curve, GaussLegendre(100))≈vsol rtol=0.5e-2
+    @test integral(fv, curve, GaussKronrod())≈vsol rtol=0.5e-2
+    @test integral(fv, curve, HAdaptiveCubature())≈vsol rtol=0.5e-2
 
     # Integral aliases
-    @test lineintegral(f, curve)≈sol rtol=0.05e-2
+    @test lineintegral(f, curve)≈sol rtol=0.5e-2
     @test_throws "not supported" surfaceintegral(f, curve)
     @test_throws "not supported" volumeintegral(f, curve)
 end


### PR DESCRIPTION
## Completed
- Merge `derivative` function into `jacobian`
- Use `differential` inside Bezier curve integral methods
- Add a new `@testitem` section for `BezierCurve` with analytic solution
- Add `jacobian` to the Documenter site API page
