### PR TITLE
v0.14.0 Release Candidate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MeshIntegrals"
 uuid = "dadec2fd-bbe0-4da4-9dbe-476c782c8e47"
-version = "0.14.0-DEV"
+version = "0.14.0"
 
 [deps]
 CoordRefSystems = "b46f11dc-f210-4604-bfba-323c1ec968cb"

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -11,7 +11,6 @@
         ux = ustrip(p.coords.x)
         (1 / sqrt(1 + cos(ux)^2)) * u"Ω/m"
     end
-    
     f(p::Meshes.Point) = f(ustrip(to(p))...)
     fv(p) = fill(f(p), 3)
 

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -37,7 +37,7 @@ end
 @testitem "Meshes.Box" setup=[Setup] begin
     # Test for currently-unsupported >3D differentials
     box4d = Box(Point(zeros(4)...), Point(ones(4)...))
-    @test_throws "Issue on GitHub" jacobian(box4d, fill(0.5, 4))
+    @test_throws "Issue on GitHub" Meshes.differential(box4d, fill(0.5, 4))
 end
 
 @testitem "Meshes.Cone" setup=[Setup] begin

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -36,6 +36,12 @@
     @test_throws DomainError jacobian(curve, [1.1])
 end
 
+@testitem "Meshes.Box" setup=[Setup] begin
+    # Test for currently-unsupported >3D differentials
+    box4d = Box(Point(zeros(4)...), Point(ones(4))...)
+    @test_throws "not supported" differential(box4d, fill(0.5, 4))
+end
+
 @testitem "Meshes.Cone" setup=[Setup] begin
     r = 2.5u"m"
     h = 2.5u"m"

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -29,7 +29,7 @@
     @test_throws "not supported" volumeintegral(f, curve)
 
     # Check Bezier-specific jacobian bounds
-    @test_throws jacobian(curve, [1.1])
+    @test_throws DomainError jacobian(curve, [1.1])
 end
 
 @testitem "Meshes.Cone" setup=[Setup] begin

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -36,7 +36,7 @@ end
 
 @testitem "Meshes.Box" setup=[Setup] begin
     # Test for currently-unsupported >3D differentials
-    box4d = Box(Point(zeros(4)...), Point(ones(4))...)
+    box4d = Box(Point(zeros(4)...), Point(ones(4)...))
     @test_throws "not supported" differential(box4d, fill(0.5, 4))
 end
 

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -37,7 +37,7 @@ end
 @testitem "Meshes.Box" setup=[Setup] begin
     # Test for currently-unsupported >3D differentials
     box4d = Box(Point(zeros(4)...), Point(ones(4)...))
-    @test_throws "Issue on GitHub" MeshIntegrals.differential(box4d, fill(0.5, 4))
+    @test integral(f -> one(Float64), box4d)≈1.0u"m^4" broken=true
 end
 
 @testitem "Meshes.Cone" setup=[Setup] begin

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -37,7 +37,7 @@ end
 @testitem "Meshes.Box" setup=[Setup] begin
     # Test for currently-unsupported >3D differentials
     box4d = Box(Point(zeros(4)...), Point(ones(4)...))
-    @test_throws "not supported" differential(box4d, fill(0.5, 4))
+    @test_throws "Issue on GitHub" jacobian(box4d, fill(0.5, 4))
 end
 
 @testitem "Meshes.Cone" setup=[Setup] begin

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -27,6 +27,9 @@
     @test lineintegral(f, curve)≈sol rtol=0.5e-2
     @test_throws "not supported" surfaceintegral(f, curve)
     @test_throws "not supported" volumeintegral(f, curve)
+
+    # Check Bezier-specific jacobian bounds
+    @test_throws jacobian(curve, [1.1])
 end
 
 @testitem "Meshes.Cone" setup=[Setup] begin

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -7,7 +7,11 @@
         [Point(t * u"m", sin(t) * u"m", 0.0u"m") for t in range(-pi, pi, length = 361)]
     )
 
-    f(x, y, z) = (1 / sqrt(1 + cos(x)^2)) * u"Ω/m"
+    function f(p::P) where {P <: Meshes.Point}
+        ux = ustrip(p.coords.x)
+        (1 / sqrt(1 + cos(ux)^2)) * u"Ω/m"
+    end
+    
     f(p::Meshes.Point) = f(ustrip(to(p))...)
     fv(p) = fill(f(p), 3)
 

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -11,7 +11,6 @@
         ux = ustrip(p.coords.x)
         (1 / sqrt(1 + cos(ux)^2)) * u"Ω/m"
     end
-    f(p::Meshes.Point) = f(ustrip(to(p))...)
     fv(p) = fill(f(p), 3)
 
     # Scalar integrand

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -37,7 +37,7 @@ end
 @testitem "Meshes.Box" setup=[Setup] begin
     # Test for currently-unsupported >3D differentials
     box4d = Box(Point(zeros(4)...), Point(ones(4)...))
-    @test_throws "Issue on GitHub" Meshes.differential(box4d, fill(0.5, 4))
+    @test_throws "Issue on GitHub" MeshIntegrals.differential(box4d, fill(0.5, 4))
 end
 
 @testitem "Meshes.Cone" setup=[Setup] begin


### PR DESCRIPTION
## Changes
- Removes `-DEV` suffix from version number
- Adds tests to complete code coverage
  - `jacobian(::BezierCurve, ts)` where `t` is outside domain `[0,1]` should throw error
  - `integral(f, geometry)` where `paramdim(geometry)>3` is (currently) broken
- Change integrand function from Bézier test set to remove deprecation warnings.
