### PR TITLE
Generalize differential element calculation to n-dims

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-CliffordNumbers = "0.1.2"
+CliffordNumbers = "0.1.4"
 CoordRefSystems = "0.12, 0.13, 0.14, 0.15"
 FastGaussQuadrature = "1"
 HCubature = "1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-CliffordNumbers = "^0.1.1"
+CliffordNumbers = "^0.1.2"
 CoordRefSystems = "0.12, 0.13, 0.14, 0.15"
 FastGaussQuadrature = "1"
 HCubature = "1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "dadec2fd-bbe0-4da4-9dbe-476c782c8e47"
 version = "0.14.1"
 
 [deps]
+CliffordNumbers = "3998ac73-6bd4-4031-8035-f167dd3ed523"
 CoordRefSystems = "b46f11dc-f210-4604-bfba-323c1ec968cb"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 HCubature = "19dc6840-f33b-545b-b366-655c7e3ffd49"
@@ -12,6 +13,7 @@ QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
+CliffordNumbers = "0.1"
 CoordRefSystems = "0.12, 0.13, 0.14, 0.15"
 FastGaussQuadrature = "1"
 HCubature = "1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-CliffordNumbers = "^0.1.2"
+CliffordNumbers = "0.1.2"
 CoordRefSystems = "0.12, 0.13, 0.14, 0.15"
 FastGaussQuadrature = "1"
 HCubature = "1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-CliffordNumbers = "0.1"
+CliffordNumbers = "^0.1.1"
 CoordRefSystems = "0.12, 0.13, 0.14, 0.15"
 FastGaussQuadrature = "1"
 HCubature = "1.5"

--- a/src/MeshIntegrals.jl
+++ b/src/MeshIntegrals.jl
@@ -2,6 +2,7 @@ module MeshIntegrals
 using CoordRefSystems: CoordRefSystems, CRS
 using LinearAlgebra: LinearAlgebra, norm, ×, ⋅
 
+import CliffordNumbers
 import FastGaussQuadrature
 import HCubature
 import Meshes

--- a/src/MeshIntegrals.jl
+++ b/src/MeshIntegrals.jl
@@ -1,8 +1,8 @@
 module MeshIntegrals
+using CliffordNumbers: CliffordNumbers, VGA, ∧
 using CoordRefSystems: CoordRefSystems, CRS
 using LinearAlgebra: LinearAlgebra, norm, ×, ⋅
 
-import CliffordNumbers
 import FastGaussQuadrature
 import HCubature
 import Meshes

--- a/src/MeshIntegrals.jl
+++ b/src/MeshIntegrals.jl
@@ -1,10 +1,10 @@
 module MeshIntegrals
 using CliffordNumbers: CliffordNumbers, VGA, ∧
 using CoordRefSystems: CoordRefSystems, CRS
-using LinearAlgebra: LinearAlgebra, ×, ⋅
 
 import FastGaussQuadrature
 import HCubature
+import LinearAlgebra
 import Meshes
 import QuadGK
 import Unitful

--- a/src/MeshIntegrals.jl
+++ b/src/MeshIntegrals.jl
@@ -1,7 +1,7 @@
 module MeshIntegrals
 using CliffordNumbers: CliffordNumbers, VGA, ∧
 using CoordRefSystems: CoordRefSystems, CRS
-using LinearAlgebra: LinearAlgebra, norm, ×, ⋅
+using LinearAlgebra: LinearAlgebra, ×, ⋅
 
 import FastGaussQuadrature
 import HCubature

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -92,7 +92,7 @@ function differential(
         geometry::G,
         ts::V
 ) where {M, CRS, G <: Meshes.Geometry{M, CRS}, V <: Union{AbstractVector, Tuple}}
-    # Calculate the Jacobian, convert each Vec -> (units, KVector)
+    # Calculate the Jacobian, convert Vec -> KVector
     J = jacobian(geometry, ts)
     J_kvecs = Iterators.map(_kvector, J)
 

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -97,7 +97,7 @@ function differential(
     J_kvecs = Iterators.map(_kvector, J)
 
     # Product of units, exterior-product of KVector's
-    uwedge((u1, kv1), (u2, kv2)) -> (u1 * u2, kv1 ∧ kv2)
+    uwedge((u1, kv1), (u2, kv2)) = (u1 * u2, kv1 ∧ kv2)
     (units, element) = foldl(uwedge, J_kvecs)
 
     return LinearAlgebra.norm(element) * units

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -75,7 +75,7 @@ function jacobian(
     sigma(i) = B(i, N - 1)(t) .* (P[(i + 1) + 1] - P[(i) + 1])
     derivative = N .* sum(sigma, 0:(N - 1))
 
-    return (derivative, )
+    return (derivative,)
 end
 
 ################################################################################

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -45,7 +45,7 @@ function jacobian(
         end
     end
 
-    return map(n -> ∂ₙr(ts, n), 1:Dim)
+    return ntuple(n -> ∂ₙr(ts, n), Dim)
 end
 
 function jacobian(
@@ -75,7 +75,7 @@ function jacobian(
     sigma(i) = B(i, N - 1)(t) .* (P[(i + 1) + 1] - P[(i) + 1])
     derivative = N .* sum(sigma, 0:(N - 1))
 
-    return [derivative]
+    return (derivative, )
 end
 
 ################################################################################

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -96,10 +96,9 @@ function differential(
     J = jacobian(geometry, ts)
     J_kvecs = Iterators.map(_kvector, J)
 
-    # Get units from Geometry type
+    # Extract units from Geometry type
     Dim = Meshes.paramdim(geometry)
-    length_unit = Unitful.unit(CoordRefSystems.lentype(CRS))
-    units = length_unit^Dim
+    units = _units(geometry)^Dim
 
     # Return norm of the exterior products
     element = foldl(∧, J_kvecs)

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -92,16 +92,13 @@ function differential(
         geometry::G,
         ts::V
 ) where {G <: Meshes.Geometry, V <: Union{AbstractVector, Tuple}}
+    # Calculate the Jacobian, convert each Vec -> (units, KVector)
     J = jacobian(geometry, ts)
+    J_kvecs = Iterators.map(_kvector, J)
 
-    # TODO generalize this with geometric algebra, e.g.: norm(foldl(∧, J))
-    if length(J) == 1
-        return norm(J[1])
-    elseif length(J) == 2
-        return norm(J[1] × J[2])
-    elseif length(J) == 3
-        return abs((J[1] × J[2]) ⋅ J[3])
-    else
-        error("Not implemented yet. Please report this as an Issue on GitHub.")
-    end
+    # Product of units, exterior-product of KVector's
+    uwedge((u1, kv1), (u2, kv2)) -> (u1 * u2, kv1 ∧ kv2)
+    (units, element) = foldl(uwedge, J_kvecs)
+
+    return LinearAlgebra.norm(element) * units
 end

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -51,7 +51,7 @@ function _integral(
     elseif N == 3
         return _integral_gk_3d(f, geometry, rule; kwargs...)
     else
-        error("Integrating this geometry type with GaussKronrod not supported.")
+        _error_unsupported_gk()
     end
 end
 
@@ -136,5 +136,5 @@ function _integral_gk_3d(
         rule::GaussKronrod;
         FP::Type{T} = Float64
 ) where {T <: AbstractFloat}
-    error("Integrating this volume type with GaussKronrod not supported.")
+    _error_unsupported_gk()
 end

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -50,7 +50,7 @@ function _integral(
         return _integral_gk_2d(f, geometry, rule; kwargs...)
     else
         _error_unsupported_combination("geometry with more than two parametric dimensions",
-                                       "GaussKronrod")
+            "GaussKronrod")
     end
 end
 

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -48,10 +48,9 @@ function _integral(
         return _integral_gk_1d(f, geometry, rule; kwargs...)
     elseif N == 2
         return _integral_gk_2d(f, geometry, rule; kwargs...)
-    elseif N == 3
-        return _integral_gk_3d(f, geometry, rule; kwargs...)
     else
-        _error_unsupported_gk()
+        _error_unsupported_combination("geometry with more than two parametric dimensions",
+                                       "GaussKronrod")
     end
 end
 
@@ -127,14 +126,4 @@ function _integral_gk_2d(
     integrand(u, v) = f(geometry2d(u, v)) * differential(geometry2d, (u, v))
     ∫₁(v) = QuadGK.quadgk(u -> integrand(u, v), zero(FP), one(FP); rule.kwargs...)[1]
     return QuadGK.quadgk(v -> ∫₁(v), zero(FP), one(FP); rule.kwargs...)[1]
-end
-
-# Integrating volumes with GaussKronrod not supported by default
-function _integral_gk_3d(
-        f,
-        geometry,
-        rule::GaussKronrod;
-        FP::Type{T} = Float64
-) where {T <: AbstractFloat}
-    _error_unsupported_gk()
 end

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -50,6 +50,8 @@ function _integral(
         return _integral_gk_2d(f, geometry, rule; kwargs...)
     elseif N == 3
         return _integral_gk_3d(f, geometry, rule; kwargs...)
+    else
+        error("Integrating this geometry type with GaussKronrod not supported.")
     end
 end
 

--- a/src/integral_aliases.jl
+++ b/src/integral_aliases.jl
@@ -25,7 +25,8 @@ function lineintegral(
     if N == 1
         return integral(f, geometry, rule; kwargs...)
     else
-        error("Performing a line integral on a geometry with $N parametric dimensions not supported.")
+        throw(ArgumentError("Performing a line integral on a geometry \
+                            with $N parametric dimensions not supported."))
     end
 end
 
@@ -56,7 +57,8 @@ function surfaceintegral(
     if N == 2
         return integral(f, geometry, rule; kwargs...)
     else
-        error("Performing a surface integral on a geometry with $N parametric dimensions not supported.")
+        throw(ArgumentError("Performing a surface integral on a geometry \
+                            with $N parametric dimensions not supported."))
     end
 end
 
@@ -87,6 +89,7 @@ function volumeintegral(
     if N == 3
         return integral(f, geometry, rule; kwargs...)
     else
-        error("Performing a volume integral on a geometry with $N parametric dimensions not supported.")
+        throw(ArgumentError("Performing a volume integral on a geometry \
+                            with $N parametric dimensions not supported."))
     end
 end

--- a/src/specializations/Tetrahedron.jl
+++ b/src/specializations/Tetrahedron.jl
@@ -15,7 +15,7 @@ function integral(
         rule::GaussLegendre;
         FP::Type{T} = Float64
 ) where {F <: Function, T <: AbstractFloat}
-    error("Integrating a Tetrahedron with GaussLegendre not supported.")
+    _error_unsupported_combination("Tetrahedron", "GaussLegendre")
 end
 
 function integral(
@@ -40,5 +40,5 @@ function integral(
         rule::HAdaptiveCubature;
         FP::Type{T} = Float64
 ) where {F <: Function, T <: AbstractFloat}
-    error("Integrating a Tetrahedron with HAdaptiveCubature not supported.")
+    _error_unsupported_combination("Tetrahedron", "HAdaptiveCubature")
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -15,12 +15,14 @@ _units(pt::Meshes.Point{M, CRS}) where {M, CRS} = first(CoordRefSystems.units(CR
 function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     units = Unitful.unit(T)
     ucoords = Iterators.map(x -> Unitful.ustrip(units, x), v.coords)
-    kvec = CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
+    kvec = CliffordNumbers.KVector{1, CliffordNumbers.VGA(Dim)}(ucoords...)
     return (units, kvec)
 end
 
+#=
 #  (units, ::CliffordNumber.KVector) -> Meshes.Vec
 function _Vec(units, kvector::CliffordNumbers.KVector{1, VGA(Dim)}) where {Dim}
     ucoords = Iterators.map(x -> units * x, kvector.data)
     Meshes.Vec(ucoords...)
 end
+=#

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,8 +11,14 @@ end
 # Extract the length units used by the CRS of a Point
 _units(pt::Meshes.Point{M, CRS}) where {M, CRS} = first(CoordRefSystems.units(CRS))
 
-# Meshes.Vec -> (units, ::CliffordNumber.KVector)
+# Meshes.Vec -> ::CliffordNumber.KVector
 function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
+    ucoords = Iterators.map(x -> Unitful.ustrip(units, x), v.coords)
+    return CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
+end
+
+# Meshes.Vec -> (units, ::CliffordNumber.KVector)
+function _ukvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     units = Unitful.unit(T)
     ucoords = Iterators.map(x -> Unitful.ustrip(units, x), v.coords)
     kvec = CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -15,7 +15,7 @@ _units(pt::Meshes.Point{M, CRS}) where {M, CRS} = first(CoordRefSystems.units(CR
 function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     units = Unitful.unit(T)
     ucoords = Iterators.map(x -> Unitful.ustrip(units, x), v.coords)
-    kvec = CliffordNumbers.KVector{1, CliffordNumbers.VGA(Dim)}(ucoords...)
+    kvec = CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
     return (units, kvec)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -18,3 +18,13 @@ function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     kvec = CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
     return (units, kvec)
 end
+
+@inline function _error_unsupported_gk()
+    msg = "Integrating this geometry type with GaussKronrod not supported."
+    throw(ArgumentError(msg))
+end
+
+@inline function _error_unsupported_combination(geometry, rule)
+    msg = "Integrating a $geometry with $rule not supported."
+    throw(ArgumentError(msg))
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -14,7 +14,7 @@ function _units(g::Meshes.Geometry{M, CRS}) where {M, CRS}
 end
 
 # Common error message structure
-@inline function _error_unsupported_combination(geometry, rule)
+function _error_unsupported_combination(geometry, rule)
     msg = "Integrating a $geometry using a $rule rule not supported."
     throw(ArgumentError(msg))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -35,12 +35,7 @@ end
 #                           Error Conditions
 ################################################################################
 
-@inline function _error_unsupported_gk()
-    msg = "Integrating this geometry type with GaussKronrod not supported."
-    throw(ArgumentError(msg))
-end
-
 @inline function _error_unsupported_combination(geometry, rule)
-    msg = "Integrating a $geometry with $rule not supported."
+    msg = "Integrating a $geometry using a $rule rule not supported."
     throw(ArgumentError(msg))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -18,11 +18,3 @@ function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     kvec = CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
     return (units, kvec)
 end
-
-#=
-#  (units, ::CliffordNumber.KVector) -> Meshes.Vec
-function _Vec(units, kvector::CliffordNumbers.KVector{1, VGA(Dim)}) where {Dim}
-    ucoords = Iterators.map(x -> units * x, kvector.data)
-    Meshes.Vec(ucoords...)
-end
-=#

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -15,6 +15,6 @@ _units(pt::Meshes.Point{M, CRS}) where {M, CRS} = first(CoordRefSystems.units(CR
 function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     units = Unitful.unit(T)
     ucoords = Iterators.map(x -> Unitful.ustrip(units, x), v.coords)
-    kvec = KVector{1, VGA(Dim)}(ucoords...)
+    kvec = CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
     return (units, kvec)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,13 +23,6 @@ function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     return CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
 end
 
-# Meshes.Vec -> (units, ::CliffordNumber.KVector)
-function _ukvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
-    units = Unitful.unit(T)
-    ucoords = Iterators.map(x -> Unitful.ustrip(units, x), v.coords)
-    kvec = CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
-    return (units, kvec)
-end
 
 ################################################################################
 #                           Error Conditions

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,6 +13,12 @@ function _units(g::Meshes.Geometry{M, CRS}) where {M, CRS}
     return Unitful.unit(CoordRefSystems.lentype(CRS))
 end
 
+# Common error message structure
+@inline function _error_unsupported_combination(geometry, rule)
+    msg = "Integrating a $geometry using a $rule rule not supported."
+    throw(ArgumentError(msg))
+end
+
 ################################################################################
 #                        CliffordNumbers Interface
 ################################################################################
@@ -21,14 +27,4 @@ end
 function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     ucoords = Iterators.map(Unitful.ustrip, v.coords)
     return CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
-end
-
-
-################################################################################
-#                           Error Conditions
-################################################################################
-
-@inline function _error_unsupported_combination(geometry, rule)
-    msg = "Integrating a $geometry using a $rule rule not supported."
-    throw(ArgumentError(msg))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -14,6 +14,6 @@ _units(pt::Meshes.Point{M, CRS}) where {M, CRS} = first(CoordRefSystems.units(CR
 # Meshes.Vec -> CliffordNumber.KVector
 function _clifford(v::Meshes.Vec{Dim, T}) where {Dim, T}
     units = Unitful.unit(T)
-    cliffordnumber = KVector{1, VGA(Dim)}(Unitful.ustrip.(units, v.coords...))
+    cliffordnumber = KVector{1, VGA(Dim)}(Unitful.ustrip.(units, v.coords)...)
     return (units, cliffordnumber)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,3 +10,10 @@ end
 
 # Extract the length units used by the CRS of a Point
 _units(pt::Meshes.Point{M, CRS}) where {M, CRS} = first(CoordRefSystems.units(CRS))
+
+# Meshes.Vec -> CliffordNumber.KVector
+function _clifford(v::Meshes.Vec{Dim, T}) where {Dim, T}
+    units = Unitful.unit(T)
+    cliffordnumber = KVector{1, VGA(Dim)}(Unitful.ustrip.(units, v.coords...))
+    return (units, cliffordnumber)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,8 +8,14 @@ function _gausslegendre(T, n)
     return T.(xs), T.(ws)
 end
 
-# Extract the length units used by the CRS of a Point
-_units(pt::Meshes.Point{M, CRS}) where {M, CRS} = first(CoordRefSystems.units(CRS))
+# Extract the length units used by the CRS of a Geometry
+function _units(g::Meshes.Geometry{M, CRS}) where {M, CRS}
+    return Unitful.unit(CoordRefSystems.lentype(CRS))
+end
+
+################################################################################
+#                        CliffordNumbers Interface
+################################################################################
 
 # Meshes.Vec -> ::CliffordNumber.KVector
 function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
@@ -24,6 +30,10 @@ function _ukvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     kvec = CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
     return (units, kvec)
 end
+
+################################################################################
+#                           Error Conditions
+################################################################################
 
 @inline function _error_unsupported_gk()
     msg = "Integrating this geometry type with GaussKronrod not supported."

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,7 +13,7 @@ _units(pt::Meshes.Point{M, CRS}) where {M, CRS} = first(CoordRefSystems.units(CR
 
 # Meshes.Vec -> ::CliffordNumber.KVector
 function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
-    ucoords = Iterators.map(x -> Unitful.ustrip(units, x), v.coords)
+    ucoords = Iterators.map(Unitful.ustrip, v.coords)
     return CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,9 +11,10 @@ end
 # Extract the length units used by the CRS of a Point
 _units(pt::Meshes.Point{M, CRS}) where {M, CRS} = first(CoordRefSystems.units(CRS))
 
-# Meshes.Vec -> CliffordNumber.KVector
-function _clifford(v::Meshes.Vec{Dim, T}) where {Dim, T}
+# Meshes.Vec -> (units, ::CliffordNumber.KVector)
+function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     units = Unitful.unit(T)
-    cliffordnumber = KVector{1, VGA(Dim)}(Unitful.ustrip.(units, v.coords)...)
-    return (units, cliffordnumber)
+    ucoords = Iterators.map(x -> Unitful.ustrip(units, x), v.coords)
+    kvec = KVector{1, VGA(Dim)}(ucoords...)
+    return (units, kvec)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -18,3 +18,9 @@ function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     kvec = CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
     return (units, kvec)
 end
+
+#  (units, ::CliffordNumber.KVector) -> Meshes.Vec
+function _Vec(units, kvector::CliffordNumbers.KVector{1, VGA(Dim)}) where {Dim}
+    ucoords = Iterators.map(x -> units * x, kvector.data)
+    Meshes.Vec(ucoords...)
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
@@ -12,6 +13,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 Aqua = "0.7, 0.8"
 ExplicitImports = "1.6.0"
+LinearAlgebra = "1"
 Meshes = "0.50, 0.51"
 QuadGK = "2.1.1"
 SpecialFunctions = "2"

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -173,7 +173,7 @@ end
     box = Box(Point(0, 0, 0, 0), Point(a, a, a, a))
 
     function f(p::P) where {P <: Meshes.Point}
-        x1, x2, x3, x4 = ustrip.(p.coords...)
+        x1, x2, x3, x4 = ustrip.(to(p).coords)
         σ(x) = sqrt(a^2 - x^2)
         (σ(x1) + σ(x2) + σ(x3) + σ(x4)) * u"Ω/m^4"
     end

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -183,13 +183,13 @@ end
     sol = 4a^3 * (π * a^2 / 4) * u"Ω"
     @test integral(f, box, GaussLegendre(100))≈sol rtol=1e-6
     @test_throws "not supported" integral(f, box, GaussKronrod())
-    @test integral(f, box, HAdaptiveCubature(rtol=1e-6))≈sol rtol=1e-6
+    @test integral(f, box, HAdaptiveCubature(rtol = 1e-6))≈sol rtol=1e-6
 
     # Vector integrand
     vsol = fill(sol, 3)
     @test integral(fv, box, GaussLegendre(100))≈vsol rtol=1e-6
     @test_throws "not supported" integral(fv, box, GaussKronrod())
-    @test integral(fv, box, HAdaptiveCubature(rtol=1e-6))≈vsol rtol=1e-6
+    @test integral(fv, box, HAdaptiveCubature(rtol = 1e-6))≈vsol rtol=1e-6
 
     # Integral aliases
     @test_throws "not supported" lineintegral(f, box)

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -170,7 +170,7 @@ end
 
 @testitem "Meshes.Box 4D" setup=[Setup] begin
     a = π
-    box = Box(Point(0, 0, 0, 0), Point(b, b, b, b))
+    box = Box(Point(0, 0, 0, 0), Point(a, a, a, a))
 
     function f(p::P) where {P <: Meshes.Point}
         x1, x2, x3, x4 = ustrip.(p.coords...)

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -169,15 +169,18 @@ end
 end
 
 @testitem "Meshes.Box 4D" setup=[Setup] begin
-    a = zero(Float64)
-    b = one(Float64)
-    box = Box(Point(a, a, a, a), Point(b, b, b, b))
+    a = π
+    box = Box(Point(0, 0, 0, 0), Point(b, b, b, b))
 
-    f(p) = 1.0
+    function f(p::P) where {P <: Meshes.Point}
+        x1, x2, x3, x4 = ustrip.(p.coords...)
+        σ(x) = sqrt(a^2 - x^2)
+        (σ(x1) + σ(x2) + σ(x3) + σ(x4)) * u"Ω/m^4"
+    end
     fv(p) = fill(f(p), 3)
 
     # Scalar integrand
-    sol = Meshes.measure(box)
+    sol = 4a^3 * (π * a^2 / 4) * u"Ω"
     @test integral(f, box, GaussLegendre(100)) ≈ sol
     @test_throws "not supported" integral(f, box, GaussKronrod())
     @test integral(f, box, HAdaptiveCubature()) ≈ sol

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -181,15 +181,15 @@ end
 
     # Scalar integrand
     sol = 4a^3 * (π * a^2 / 4) * u"Ω"
-    @test integral(f, box, GaussLegendre(100)) ≈ sol
+    @test integral(f, box, GaussLegendre(100))≈sol rtol=1e-6
     @test_throws "not supported" integral(f, box, GaussKronrod())
-    @test integral(f, box, HAdaptiveCubature()) ≈ sol
+    @test integral(f, box, HAdaptiveCubature(rtol=1e-6))≈sol rtol=1e-6
 
     # Vector integrand
     vsol = fill(sol, 3)
-    @test integral(fv, box, GaussLegendre(100)) ≈ vsol
+    @test integral(fv, box, GaussLegendre(100))≈vsol rtol=1e-6
     @test_throws "not supported" integral(fv, box, GaussKronrod())
-    @test integral(fv, box, HAdaptiveCubature()) ≈ vsol
+    @test integral(fv, box, HAdaptiveCubature(rtol=1e-6))≈vsol rtol=1e-6
 
     # Integral aliases
     @test_throws "not supported" lineintegral(f, box)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -5,12 +5,6 @@
     v = Meshes.Vec(3, 4)
     @test norm(MeshIntegrals._kvector(v)) ≈ 5.0
 
-    # _ukvector
-    v = Meshes.Vec(3, 4)
-    (units, kvector) = MeshIntegrals._ukvector(v)
-    @test units == u"m"
-    @test norm(kvector) ≈ 5.0
-
     # _units
     p = Point(1.0u"cm", 2.0u"mm", 3.0u"m")
     @test MeshIntegrals._units(p) == u"m"

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,17 @@
+@testitem "Utilities" setup=[Setup] begin
+    using LinearAlgebra: norm
+
+    # _kvector
+    v = Meshes.Vec(3, 4)
+    @test norm(MeshIntegrals._kvector(v)) ≈ 5.0
+
+    # _ukvector
+    v = Meshes.Vec(3, 4)
+    (units, kvector) = MeshIntegrals._ukvector(v)
+    @test units == u"m"
+    @test norm(kvector) ≈ 5.0
+
+    # _units
+    p = Point(1.0u"cm", 2.0u"mm", 3.0u"m")
+    @test MeshIntegrals._units(p) == u"m"
+end


### PR DESCRIPTION
## Changes
- Uses geometric algebra to generalize `differential` to handle geometries with arbitrary numbers of parametric dimensions.
- Adds CliffordNumbers.jl as a dependency.
- Converts all prior usages of the generic `error` function into throwing more appropriate/specific error types.
- Implements un-broken tests for 4D `Box` now that this is fixed.
- Minor API change to `jacobian` such that `(geometry, ts) -> ::NTuple{paramdim(geometry), Meshes.Vec}`