### PR TITLE
Add tests for `Ellipsoid` and `Hexahedron`

### DIFF
--- a/docs/src/supportmatrix.md
+++ b/docs/src/supportmatrix.md
@@ -34,11 +34,15 @@ Cubature integration rules are recommended (and the default).
 | `Cylinder` | ✅ | 🛑 | ✅ |
 | `CylinderSurface` | ✅ | ✅ | ✅ |
 | `Disk` | ✅ | ✅ | ✅ |
+| `Ellipsoid` | ✅ | ✅ | ✅ |
 | `Frustum` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) |
 | `FrustumSurface` | ✅ | ✅ | ✅ |
+| `Hexahedron` | ✅ | ✅ | ✅ |
 | `Line` | ✅ | ✅ | ✅ |
 | `ParaboloidSurface` | ✅ | ✅ | ✅ |
 | `Plane` | ✅ | ✅ | ✅ |
+| `Polyarea` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) |
+| `Pyramid` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) |
 | `Quadrangle` | ✅ | ✅ | ✅ |
 | `Ray` | ✅ | ✅ | ✅ |
 | `Ring` | ✅ | ✅ | ✅ |
@@ -50,3 +54,4 @@ Cubature integration rules are recommended (and the default).
 | `Tetrahedron` in `𝔼{3}` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/40) | ✅ | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/40) |
 | `Triangle` | ✅ | ✅ | ✅ |
 | `Torus` | ✅ | ✅ | ✅ |
+| `Wedge` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) |

--- a/docs/src/supportmatrix.md
+++ b/docs/src/supportmatrix.md
@@ -27,7 +27,7 @@ Cubature integration rules are recommended (and the default).
 | `BezierCurve` | ✅ | ✅ | ✅ |
 | `Box` in `𝔼{1}` | ✅ | ✅ | ✅ |
 | `Box` in `𝔼{2}` | ✅ | ✅ | ✅ |
-| `Box` in `𝔼{3}` | ✅ | 🛑 | ✅ |
+| `Box` in `𝔼{≥3}` | ✅ | 🛑 | ✅ |
 | `Circle` | ✅ | ✅ | ✅ |
 | `Cone` | ✅ | ✅ | ✅ |
 | `ConeSurface` | ✅ | ✅ | ✅ |

--- a/docs/src/supportmatrix.md
+++ b/docs/src/supportmatrix.md
@@ -35,14 +35,14 @@ Cubature integration rules are recommended (and the default).
 | `CylinderSurface` | ✅ | ✅ | ✅ |
 | `Disk` | ✅ | ✅ | ✅ |
 | `Ellipsoid` | ✅ | ✅ | ✅ |
-| `Frustum` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) |
+| `Frustum` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/28) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/28) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/28) |
 | `FrustumSurface` | ✅ | ✅ | ✅ |
 | `Hexahedron` | ✅ | ✅ | ✅ |
 | `Line` | ✅ | ✅ | ✅ |
 | `ParaboloidSurface` | ✅ | ✅ | ✅ |
 | `Plane` | ✅ | ✅ | ✅ |
-| `Polyarea` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) |
-| `Pyramid` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) |
+| `Polyarea` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/28) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/28) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/28) |
+| `Pyramid` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/28) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/28) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/28) |
 | `Quadrangle` | ✅ | ✅ | ✅ |
 | `Ray` | ✅ | ✅ | ✅ |
 | `Ring` | ✅ | ✅ | ✅ |
@@ -54,4 +54,4 @@ Cubature integration rules are recommended (and the default).
 | `Tetrahedron` in `𝔼{3}` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/40) | ✅ | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/40) |
 | `Triangle` | ✅ | ✅ | ✅ |
 | `Torus` | ✅ | ✅ | ✅ |
-| `Wedge` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/57) |
+| `Wedge` | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/28) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/28) | [🎗️](https://github.com/mikeingold/MeshIntegrals.jl/issues/28) |

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -427,13 +427,13 @@ end
     # Scalar integrand
     sol = Meshes.measure(hexahedron)
     @test integral(f, hexahedron, GaussLegendre(100)) ≈ sol
-    @test_throws "not supported" integral(f, hexahedron, GaussKronrod()) ≈ sol
+    @test_throws "not supported" integral(f, hexahedron, GaussKronrod())≈sol
     @test integral(f, hexahedron, HAdaptiveCubature()) ≈ sol
 
     # Vector integrand
     vsol = fill(sol, 3)
     @test integral(fv, hexahedron, GaussLegendre(100)) ≈ vsol
-    @test_throws "not supported" integral(fv, hexahedron, GaussKronrod()) ≈ vsol
+    @test_throws "not supported" integral(fv, hexahedron, GaussKronrod())≈vsol
     @test integral(fv, hexahedron, HAdaptiveCubature()) ≈ vsol
 
     # Integral aliases

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -352,6 +352,32 @@ end
     @test_throws "not supported" volumeintegral(f, disk)
 end
 
+@testitem "Meshes.Ellipsoid" setup=[Setup] begin
+    origin = Point(0, 0, 0)
+    radii = (1.0, 2.0, 0.5)
+    ellipsoid = Ellipsoid(radii, origin)
+
+    f(p) = 1.0
+    fv(p) = fill(f(p), 3)
+
+    # Scalar integrand
+    sol = Meshes.measure(ellipsoid)
+    @test integral(f, ellipsoid, GaussLegendre(100))≈sol rtol=1e-2
+    @test integral(f, ellipsoid, GaussKronrod())≈sol rtol=1e-2
+    @test integral(f, ellipsoid, HAdaptiveCubature())≈sol rtol=1e-2
+
+    # Vector integrand
+    vsol = fill(sol, 3)
+    @test integral(fv, ellipsoid, GaussLegendre(100))≈vsol rtol=1e-2
+    @test integral(fv, ellipsoid, GaussKronrod())≈vsol rtol=1e-2
+    @test integral(fv, ellipsoid, HAdaptiveCubature())≈vsol rtol=1e-2
+
+    # Integral aliases
+    @test_throws "not supported" lineintegral(f, ellipsoid)
+    @test surfaceintegral(f, ellipsoid)≈sol rtol=1e-2
+    @test_throws "not supported" volumeintegral(f, ellipsoid)
+end
+
 @testitem "Meshes.FrustumSurface" setup=[Setup] begin
     # Create a frustum whose radius halves at the top,
     # i.e. the bottom half of a cone by height
@@ -389,6 +415,31 @@ end
     @test integral(fv, frustum, GaussLegendre(100))≈vsol rtol=1e-6
     @test integral(fv, frustum, GaussKronrod())≈vsol rtol=1e-6
     @test integral(fv, frustum, HAdaptiveCubature()) ≈ vsol
+end
+
+@testitem "Meshes.Hexahedron" setup=[Setup] begin
+    hexahedron = Hexahedron(Point(0, 0, 0), Point(2, 0, 0), Point(2, 2, 0),
+        Point(0, 2, 0), Point(0, 0, 2), Point(1, 0, 2), Point(1, 1, 2), Point(0, 1, 2))
+
+    f(p) = 1.0
+    fv(p) = fill(f(p), 3)
+
+    # Scalar integrand
+    sol = Meshes.measure(hexahedron)
+    @test integral(f, hexahedron, GaussLegendre(100)) ≈ sol
+    @test_throws "not supported" integral(f, hexahedron, GaussKronrod()) ≈ sol
+    @test integral(f, hexahedron, HAdaptiveCubature()) ≈ sol
+
+    # Vector integrand
+    vsol = fill(sol, 3)
+    @test integral(fv, hexahedron, GaussLegendre(100)) ≈ vsol
+    @test_throws "not supported" integral(fv, hexahedron, GaussKronrod()) ≈ vsol
+    @test integral(fv, hexahedron, HAdaptiveCubature()) ≈ vsol
+
+    # Integral aliases
+    @test_throws "not supported" lineintegral(f, hexahedron)
+    @test_throws "not supported" surfaceintegral(f, hexahedron)
+    @test volumeintegral(f, hexahedron) ≈ sol
 end
 
 @testitem "Meshes.Line" setup=[Setup] begin

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -360,6 +360,7 @@ end
     f(p) = 1.0
     fv(p) = fill(f(p), 3)
 
+    # Tolerances are higher due to `measure` being only an approximation
     # Scalar integrand
     sol = Meshes.measure(ellipsoid)
     @test integral(f, ellipsoid, GaussLegendre(100))≈sol rtol=1e-2


### PR DESCRIPTION
Integrating `Ellipsoid` and `Hexahedron` should simply work. However, I needed to set pretty high tolerances for `Ellipsoid` for some reason. Do you know why @mikeingold?
I also added other geometries, which do not implement any parametric function yet, in the support matrix, cf. #57