### PR TITLE
Testing fix for Documenter issue #103

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,4 +18,6 @@ makedocs(
 
 deploydocs(repo = "github.com/mikeingold/MeshIntegrals.jl.git",
     devbranch = "main",
-    push_preview = true)
+    versions = ["stable" => "v^", "v#.#", "dev" => "dev"],
+    push_preview = true
+)


### PR DESCRIPTION
I'm taking a swing at fixing #103.

The [deployment docs](https://documenter.juliadocs.org/stable/man/hosting/#Documentation-Versions) and [`deploydocs` docstring](https://documenter.juliadocs.org/stable/lib/public/#Documenter.deploydocs) aren't very descriptive on this point, but from looking around at other packages this `versions` argument seems like it might be needed.

I suspect this won't retroactively include missed versions, though there's [a note on this point](https://documenter.juliadocs.org/stable/man/hosting/#Fixing-broken-release-deployments) that suggests a workaround is to `git tag` old commits with `v0.xx.x-anything` to re-trigger workflows.