### PR TITLE
Add an extended tag for time-intensive unit tests

### DIFF
--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -168,7 +168,7 @@ end
     @test volumeintegral(f, box) ≈ sol
 end
 
-@testitem "Meshes.Box 4D" setup=[Setup] begin
+@testitem "Meshes.Box 4D" tags=[:extended] setup=[Setup] begin
     a = π
     box = Box(Point(0, 0, 0, 0), Point(a, a, a, a))
 
@@ -804,7 +804,7 @@ end
     @test_throws "not supported" volumeintegral(f, sphere)
 end
 
-@testitem "Meshes.Tetrahedron" setup=[Setup] begin
+@testitem "Meshes.Tetrahedron" tags=[:extended] setup=[Setup] begin
     pt_n = Point(0, 1, 0)
     pt_w = Point(-1, 0, 0)
     pt_e = Point(1, 0, 0)

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -138,6 +138,9 @@ end
     @test_throws "not supported" lineintegral(f, box)
     @test surfaceintegral(f, box) ≈ sol
     @test_throws "not supported" volumeintegral(f, box)
+
+    # Test jacobian with wrong number of parametric coordinates
+    @test_throws ArgumentError jacobian(box, zeros(3))
 end
 
 @testitem "Meshes.Box 3D" setup=[Setup] begin
@@ -195,9 +198,6 @@ end
     @test_throws "not supported" lineintegral(f, box)
     @test_throws "not supported" surfaceintegral(f, box)
     @test_throws "not supported" volumeintegral(f, box)
-
-    # Test jacobian with wrong number of parametric coordinates
-    @test_throws ArgumentError jacobian(box, zeros(2))
 end
 
 @testitem "Meshes.Circle" setup=[Setup] begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using TestItemRunner
 using TestItems
 
-@run_package_tests verbose = true
+# For CI, run all tests not marked with the :extended tag
+@run_package_tests filter=ti->!(:extended in ti.tags) verbose=true
 
 @testsnippet Setup begin
     using Meshes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using TestItemRunner
 using TestItems
 
 # For CI, run all tests not marked with the :extended tag
-@run_package_tests filter=ti->!(:extended in ti.tags) verbose=true
+@run_package_tests filter=ti -> !(:extended in ti.tags) verbose=true
 
 @testsnippet Setup begin
     using Meshes


### PR DESCRIPTION
## Changes
- Establishes an `:extended` `@testitem` tag for time-intensive tests that can forgo CI (still available for local testing in VS Code)
  - Tagged `Box in 4D` and `Tetrahedron`
  - 

This comes with the downside that integration of these two geometry types won’t be checked automatically with CI, and a code coverage “reduction”, but I think the actual practical impact is minor. For any changes that would specifically impact these two geometries, we’ll have to make sure to run the tests locally. Slightly inconvenient for a niche case but allows for faster iterations in development of everything else.