### PR TITLE
Add more analytic tests

### DIFF
--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -36,24 +36,20 @@ end
     using SpecialFunctions: erf
     using LinearAlgebra: norm
 
-    center = Point(0, 0, 0)
+    center = Point(1, 2, 3)
     radius = 2.8u"m"
     ball = Ball(center, radius)
 
     function f(p::P) where {P <: Meshes.Point}
-        ur = norm(to(p))
+        ur = norm(to(p) - to(center))
         r = ustrip(u"m", ur)
         exp(-r^2)
-        # 1 / r
-        # 1.0
     end
     fv(p) = fill(f(p), 3)
 
     # Scalar integrand
     r = ustrip(u"m", radius)
     sol = (π^(3/2) * erf(r) - 2π * exp(-r^2) * r) * u"m^3"   # for f(p) = exp(-r^2)
-    # sol = 2π * radius^2 * u"m"     # for f(p) = 1/r
-    # sol = (4 / 3) * π * radius^3   # for f(p) = 1
     @test integral(f, ball, GaussLegendre(100)) ≈ sol
     @test_throws "not supported" integral(f, ball, GaussKronrod())≈sol
     @test integral(f, ball, HAdaptiveCubature()) ≈ sol

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -33,26 +33,27 @@
 end
 
 @testitem "Meshes.Ball 3D" setup=[Setup] begin
-    # using SpecialFunctions: erf
+    using SpecialFunctions: erf
+    using LinearAlgebra: norm
 
-    center = Point(1, 2, 3)
+    center = Point(0, 0, 0)
     radius = 2.8u"m"
     ball = Ball(center, radius)
 
     function f(p::P) where {P <: Meshes.Point}
-        ur = hypot(p.coords.x, p.coords.y)
+        ur = norm(to(p))
         r = ustrip(u"m", ur)
-        # exp(-r^2)
+        exp(-r^2)
         # 1 / r
-        1.0
+        # 1.0
     end
     fv(p) = fill(f(p), 3)
 
     # Scalar integrand
-    # r = ustrip(u"m", radius)
-    # sol = (π^(3/2) * erf(r) - 2π * exp(-r^2) * r) * u"m^3"   # for f(p) = exp(-r^2)
+    r = ustrip(u"m", radius)
+    sol = (π^(3/2) * erf(r) - 2π * exp(-r^2) * r) * u"m^3"   # for f(p) = exp(-r^2)
     # sol = 2π * radius^2 * u"m"     # for f(p) = 1/r
-    sol = (4 / 3) * π * radius^3   # for f(p) = 1
+    # sol = (4 / 3) * π * radius^3   # for f(p) = 1
     @test integral(f, ball, GaussLegendre(100)) ≈ sol
     @test_throws "not supported" integral(f, ball, GaussKronrod())≈sol
     @test integral(f, ball, HAdaptiveCubature()) ≈ sol

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -50,7 +50,7 @@ end
 
     # Scalar integrand
     r = ustrip(u"m", radius)
-    sol = (π^(3 / 2) * erf(r) - 2π * exp(-r^2) * r) * u"m^3"   # for f(p) = exp(-r^2)
+    sol = (π^(3 / 2) * erf(r) - 2π * exp(-r^2) * r) * u"m^3"
     @test integral(f, ball, GaussLegendre(100)) ≈ sol
     @test_throws "not supported" integral(f, ball, GaussKronrod())≈sol
     @test integral(f, ball, HAdaptiveCubature()) ≈ sol

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -219,7 +219,7 @@ end
 
 @testitem "Meshes.Circle" setup=[Setup] begin
     center = Point(0, 3, 0)
-    n̂ = Vec(1/2, 1/2, sqrt(2)/2)
+    n̂ = Vec(1 / 2, 1 / 2, sqrt(2) / 2)
     plane = Plane(center, n̂)
     radius = 4.4
     circle = Circle(plane, radius)
@@ -368,7 +368,7 @@ end
 
 @testitem "Meshes.Disk" setup=[Setup] begin
     center = Point(1, 2, 3)
-    n̂ = Vec(1/2, 1/2, sqrt(2)/2)
+    n̂ = Vec(1 / 2, 1 / 2, sqrt(2) / 2)
     plane = Plane(center, n̂)
     radius = 2.5
     disk = Disk(plane, radius)

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -49,7 +49,7 @@ end
 
     # Scalar integrand
     r = ustrip(u"m", radius)
-    sol = (π^(3/2) * erf(r) - 2π * exp(-r^2) * r) * u"m^3"   # for f(p) = exp(-r^2)
+    sol = (π^(3 / 2) * erf(r) - 2π * exp(-r^2) * r) * u"m^3"   # for f(p) = exp(-r^2)
     @test integral(f, ball, GaussLegendre(100)) ≈ sol
     @test_throws "not supported" integral(f, ball, GaussKronrod())≈sol
     @test integral(f, ball, HAdaptiveCubature()) ≈ sol

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -355,16 +355,22 @@ end
 end
 
 @testitem "Meshes.Disk" setup=[Setup] begin
-    origin = Point(0, 0, 0)
-    ẑ = Vec(0, 0, 1)
-    xy_plane = Plane(origin, ẑ)
-    disk = Disk(xy_plane, 2.5)
+    center = Point(1, 2, 3)
+    n̂ = Vec(1/2, 1/2, sqrt(2)/2)
+    plane = Plane(center, n̂)
+    radius = 2.5
+    disk = Disk(plane, radius)
 
-    f(p) = 1.0
+    function f(p::P) where {P <: Meshes.Point}
+        offset = p - center
+        ur = hypot(offset.coords...)
+        r = ustrip(u"m", ur)
+        exp(-r^2)
+    end
     fv(p) = fill(f(p), 3)
 
     # Scalar integrand
-    sol = Meshes.measure(disk)
+    sol = (π - π * exp(-radius^2)) * u"m^2"
     @test integral(f, disk, GaussLegendre(100)) ≈ sol
     @test integral(f, disk, GaussKronrod()) ≈ sol
     @test integral(f, disk, HAdaptiveCubature()) ≈ sol

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -36,7 +36,7 @@ end
     using SpecialFunctions: erf
     using LinearAlgebra: norm
 
-    center = Point(1, 2, 3)
+    const center = Point(1, 2, 3)
     radius = 2.8u"m"
     ball = Ball(center, radius)
 

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -4,13 +4,18 @@
 
 @testitem "Meshes.Ball 2D" setup=[Setup] begin
     origin = Point(0, 0)
-    ball = Ball(origin, 2.8)
+    radius = 2.8
+    ball = Ball(origin, radius)
 
-    f(p) = 1.0
+    function f(p::P) where {P <: Meshes.Point}
+        ur = hypot(p.coords.x, p.coords.y)
+        r = ustrip(u"m", ur)
+        exp(-r^2)
+    end
     fv(p) = fill(f(p), 3)
 
     # Scalar integrand
-    sol = Meshes.measure(ball)
+    sol = (π - π * exp(-radius^2)) * u"m^2"
     @test integral(f, ball, GaussLegendre(100)) ≈ sol
     @test integral(f, ball, GaussKronrod()) ≈ sol
     @test integral(f, ball, HAdaptiveCubature()) ≈ sol

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -33,7 +33,6 @@ end
 
 @testitem "Meshes.Ball 3D" setup=[Setup] begin
     using SpecialFunctions: erf
-    using LinearAlgebra: norm
 
     center = Point(1, 2, 3)
     radius = 2.8u"m"
@@ -544,7 +543,6 @@ end
     # If the version is specified as minimal compat bound in the Project.toml, the downgrade test fails
     if pkgversion(Meshes) >= v"0.51.20"
         using CoordRefSystems: Polar
-        using LinearAlgebra: norm
 
         # Parameterize a circle centered on origin with specified radius
         radius = 4.4

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -796,14 +796,23 @@ end
 end
 
 @testitem "Meshes.Sphere 3D" setup=[Setup] begin
-    origin = Point(0, 0, 0)
-    sphere = Sphere(origin, 4.4)
+    using CoordRefSystems: Cartesian, Spherical
 
-    f(p) = 1.0
+    center = Point(1, 2, 3)
+    radius = 4.4u"m"
+    sphere = Sphere(center, radius)
+
+    function f(p::P) where {P <: Meshes.Point}
+        rθφ = convert(Spherical, Cartesian((p - center)...))
+        r = ustrip(rθφ.r)
+        θ = ustrip(rθφ.θ)
+        φ = ustrip(rθφ.ϕ)
+        sin(φ)^2 + cos(θ)^2
+    end
     fv(p) = fill(f(p), 3)
 
     # Scalar integrand
-    sol = Meshes.measure(sphere)
+    sol = (2π * radius^2) + (4π / 3 * radius^2)
     @test integral(f, sphere, GaussLegendre(100)) ≈ sol
     @test integral(f, sphere, GaussKronrod()) ≈ sol
     @test integral(f, sphere, HAdaptiveCubature()) ≈ sol

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -8,8 +8,7 @@
     ball = Ball(origin, radius)
 
     function f(p::P) where {P <: Meshes.Point}
-        ur = hypot(p.coords.x, p.coords.y)
-        r = ustrip(u"m", ur)
+        r = ustrip(u"m", norm(to(p)))
         exp(-r^2)
     end
     fv(p) = fill(f(p), 3)
@@ -216,7 +215,7 @@ end
 end
 
 @testitem "Meshes.Circle" setup=[Setup] begin
-    center = Point(0, 3, 0)
+    center = Point(1, 2, 3)
     n̂ = Vec(1 / 2, 1 / 2, sqrt(2) / 2)
     plane = Plane(center, n̂)
     radius = 4.4
@@ -224,8 +223,7 @@ end
 
     function f(p::P) where {P <: Meshes.Point}
         offset = p - center
-        ur = hypot(offset.coords...)
-        r = ustrip(u"m", ur)
+        r = ustrip(u"m", norm(offset))
         exp(-r^2)
     end
     fv(p) = fill(f(p), 3)
@@ -373,8 +371,7 @@ end
 
     function f(p::P) where {P <: Meshes.Point}
         offset = p - center
-        ur = hypot(offset.coords...)
-        r = ustrip(u"m", ur)
+        r = ustrip(u"m", norm(offset))
         exp(-r^2)
     end
     fv(p) = fill(f(p), 3)
@@ -494,8 +491,7 @@ end
     line = Line(a, b)
 
     function f(p::P) where {P <: Meshes.Point}
-        ur = hypot(p.coords.x, p.coords.y, p.coords.z)
-        r = ustrip(u"m", ur)
+        r = ustrip(u"m", norm(to(p)))
         exp(-r^2)
     end
     fv(p) = fill(f(p), 3)
@@ -597,8 +593,7 @@ end
     plane = Plane(p, v)
 
     function f(p::P) where {P <: Meshes.Point}
-        ur = hypot(p.coords.x, p.coords.y, p.coords.z)
-        r = ustrip(u"m", ur)
+        r = ustrip(u"m", norm(to(p)))
         exp(-r^2)
     end
     fv(p) = fill(f(p), 3)
@@ -626,8 +621,7 @@ end
     quadrangle = Quadrangle((-1.0, 0.0), (-1.0, 1.0), (1.0, 1.0), (1.0, 0.0))
 
     function f(p::P) where {P <: Meshes.Point}
-        ur = hypot(p.coords.x, p.coords.y)
-        r = ustrip(u"m", ur)
+        r = ustrip(u"m", norm(to(p)))
         exp(-r^2)
     end
     fv(p) = fill(f(p), 3)
@@ -656,8 +650,7 @@ end
     ray = Ray(a, v)
 
     function f(p::P) where {P <: Meshes.Point}
-        ur = hypot(p.coords.x, p.coords.y, p.coords.z)
-        r = ustrip(u"m", ur)
+        r = ustrip(u"m", norm(to(p)))
         exp(-r^2)
     end
     fv(p) = fill(f(p), 3)
@@ -752,8 +745,7 @@ end
     a, b = (7.1, 4.6)  # arbitrary constants > 0
 
     function f(p::P) where {P <: Meshes.Point}
-        ur = hypot(p.coords.x, p.coords.y, p.coords.z)
-        r = ustrip(u"m", ur)
+        r = ustrip(u"m", norm(to(p)))
         exp(r * log(a) + (1 - r) * log(b))
     end
     fv(p) = fill(f(p), 3)
@@ -782,8 +774,7 @@ end
     sphere = Sphere(origin, radius)
 
     function f(p::P) where {P <: Meshes.Point}
-        ur = hypot(p.coords.x, p.coords.y)
-        r = ustrip(u"m", ur)
+        r = ustrip(u"m", norm(to(p)))
         exp(-r^2)
     end
     fv(p) = fill(f(p), 3)

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -201,16 +201,22 @@ end
 end
 
 @testitem "Meshes.Circle" setup=[Setup] begin
-    origin = Point(0, 0, 0)
-    ẑ = Vec(0, 0, 1)
-    xy_plane = Plane(origin, ẑ)
-    circle = Circle(xy_plane, 2.5)
+    center = Point(0, 3, 0)
+    n̂ = Vec(1/2, 1/2, sqrt(2)/2)
+    plane = Plane(center, n̂)
+    radius = 4.4
+    circle = Circle(plane, radius)
 
-    f(p) = 1.0
+    function f(p::P) where {P <: Meshes.Point}
+        offset = p - center
+        ur = hypot(offset.coords...)
+        r = ustrip(u"m", ur)
+        exp(-r^2)
+    end
     fv(p) = fill(f(p), 3)
 
     # Scalar integrand
-    sol = Meshes.measure(circle)
+    sol = 2π * radius * exp(-radius^2) * u"m"
     @test integral(f, circle, GaussLegendre(100)) ≈ sol
     @test integral(f, circle, GaussKronrod()) ≈ sol
     @test integral(f, circle, HAdaptiveCubature()) ≈ sol

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -36,12 +36,13 @@ end
     using SpecialFunctions: erf
     using LinearAlgebra: norm
 
-    const center = Point(1, 2, 3)
+    center = Point(1, 2, 3)
     radius = 2.8u"m"
     ball = Ball(center, radius)
 
     function f(p::P) where {P <: Meshes.Point}
-        ur = norm(to(p) - to(center))
+        offset = p - center
+        ur = norm(offset)
         r = ustrip(u"m", ur)
         exp(-r^2)
     end

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -33,14 +33,26 @@
 end
 
 @testitem "Meshes.Ball 3D" setup=[Setup] begin
-    origin = Point(0, 0, 0)
-    ball = Ball(origin, 2.8)
+    # using SpecialFunctions: erf
 
-    f(p) = 1.0
+    center = Point(1, 2, 3)
+    radius = 2.8u"m"
+    ball = Ball(center, radius)
+
+    function f(p::P) where {P <: Meshes.Point}
+        ur = hypot(p.coords.x, p.coords.y)
+        r = ustrip(u"m", ur)
+        # exp(-r^2)
+        # 1 / r
+        1.0
+    end
     fv(p) = fill(f(p), 3)
 
     # Scalar integrand
-    sol = Meshes.measure(ball)
+    # r = ustrip(u"m", radius)
+    # sol = (π^(3/2) * erf(r) - 2π * exp(-r^2) * r) * u"m^3"   # for f(p) = exp(-r^2)
+    # sol = 2π * radius^2 * u"m"     # for f(p) = 1/r
+    sol = (4 / 3) * π * radius^3   # for f(p) = 1
     @test integral(f, ball, GaussLegendre(100)) ≈ sol
     @test_throws "not supported" integral(f, ball, GaussKronrod())≈sol
     @test integral(f, ball, HAdaptiveCubature()) ≈ sol

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using TestItems
 @run_package_tests filter=ti -> !(:extended in ti.tags) verbose=true
 
 @testsnippet Setup begin
+    using LinearAlgebra: norm
     using Meshes
     using Unitful
 end


### PR DESCRIPTION
## Changes
- Continues to make progress on #67 
  - [x] `Ball` (2D)
  - [x] `Ball` (3D)
  - [x] `Circle`
  - [x] `Disk`
  - [x] `Sphere` (3D)
- Add `LinearAlgebra` to standard test snippet and convert usages from `hypot` to `norm`